### PR TITLE
Make Contig members final. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,6 @@
     <mockito.version>1.10.8</mockito.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.targetEncoding>UTF-8</project.build.targetEncoding>
-    <java.version>1.6</java.version>
+    <java.version>1.7</java.version>
   </properties>
 </project>

--- a/src/main/java/com/google/cloud/genomics/utils/Contig.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Contig.java
@@ -37,14 +37,17 @@ import static java.util.Objects.hash;
 import static java.util.Objects.requireNonNull;
 
 public class Contig implements Serializable {
+
+  private static final long serialVersionUID = -1730387112193404207L;
+
   public static final long DEFAULT_NUMBER_OF_BASES_PER_SHARD = 100000;
 
   // If not running all contigs, we default to BRCA1
   public static final String BRCA1 = "17:41196311:41277499";
 
-  public String referenceName;
-  public long start;
-  public long end;
+  public final String referenceName;
+  public final long start;
+  public final long end;
 
   public Contig(String referenceName, long start, long end) {
     this.referenceName = requireNonNull(referenceName);


### PR DESCRIPTION
Make Contig member instances final, to prevent unintended mutations.

Mark the project as Java 1.7 as Contig uses this level of compatibility.