### PR TITLE
Client-side shard fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.google.cloud.genomics</groupId>
   <artifactId>google-genomics-utils</artifactId>
   <packaging>jar</packaging>
-  <version>v1beta2-0.20-SNAPSHOT</version>
+  <version>v1beta2-0.21-SNAPSHOT</version>
 
   <organization>
     <name>Google</name>

--- a/src/main/java/com/google/cloud/genomics/utils/Contig.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Contig.java
@@ -42,6 +42,8 @@ public class Contig implements Serializable {
 
   public static final long DEFAULT_NUMBER_OF_BASES_PER_SHARD = 100000;
 
+  public enum SexChromosomeFilter { INCLUDE_XY, EXCLUDE_XY }
+  
   // If not running all contigs, we default to BRCA1
   public static final String BRCA1 = "17:41196311:41277499";
 
@@ -118,15 +120,26 @@ public class Contig implements Serializable {
         });
   }
 
+  /**
+   * Retrieve the list of all the reference names and their start/end positions for the variant set.
+   * 
+   * @param genomics - The {@link Genomics} stub.
+   * @param variantSetId - The id of the variant set to query.
+   * @param sexChromosomeFilter - An enum value indicating how sex chromosomes should be
+   *        handled in the result.
+   * @return The list of all references in the variant set.
+   * @throws IOException
+   */
   public static List<Contig> getContigsInVariantSet(Genomics genomics, String variantSetId,
-      boolean excludeXY) throws IOException {
+      SexChromosomeFilter sexChromosomeFilter) throws IOException {
     List<Contig> contigs = Lists.newArrayList();
 
     VariantSet variantSet = genomics.variantsets().get(variantSetId).execute();
     for (ReferenceBound bound : variantSet.getReferenceBounds()) {
       String contig = bound.getReferenceName().toLowerCase();
-      if (excludeXY && (contig.contains("x") || contig.contains("y"))) {
-        // X and Y skew analysis results
+      if (sexChromosomeFilter == SexChromosomeFilter.EXCLUDE_XY
+          && (contig.contains("x") || contig.contains("y"))) {
+        // X and Y can skew some analysis results
         continue;
       }
 

--- a/src/main/java/com/google/cloud/genomics/utils/Paginator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Paginator.java
@@ -97,13 +97,7 @@ import java.util.Iterator;
  */
 public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
   
-  /**
-   * For Paginators iterating over a range of data, this enum specifies whether the records returned
-   * should overlap the start of the shard (the default) or start within the shard.
-   * 
-   * Ranges are half-open 0-based, so [start,end)
-   */
-  public enum ShardBoundary { OVERLAPS, STARTS_IN }
+  public enum ShardBoundary { OVERLAPS, STRICT }
 
   private abstract static class AbstractDatasets<B> extends Paginator<
       Genomics.Datasets,
@@ -383,23 +377,47 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
       Genomics.Reads.Search,
       SearchReadsResponse,
       Read> {
+    
+    private final ShardBoundary shardBoundary;
+    private Predicate<Read> shardPredicate = null;
 
     /**
      * Static factory method.
      *
+     * The reads search API by default returns all reads that overlap the specified range.
+     * Ranges are half-open 0-based, so [start,end)
+     *
+     * Cluster compute jobs attempting to shard the data will see any records that span a shard
+     * boundary in both shards. In some cases this might be okay, in others it is not.
+     * 
      * @param genomics The {@link Genomics} stub.
+     * @param shardBoundary Use ShardBoundary.OVERLAPS for the default behavior or use
+     *        ShardBoundary.STRICT to ensure that a record does not appear in more than one shard.
      * @return the new paginator.
      */
-    public static Reads create(Genomics genomics) {
-      return new Reads(genomics);
+    public static Reads create(Genomics genomics, ShardBoundary shardBoundary) {
+      return new Reads(genomics, shardBoundary);
     }
 
-    private Reads(Genomics genomics) {
+    private Reads(Genomics genomics, ShardBoundary shardBoundary) {
       super(genomics);
+      this.shardBoundary = shardBoundary;
     }
 
     @Override Genomics.Reads.Search createSearch(Genomics.Reads api, final SearchReadsRequest request,
         Optional<String> pageToken) throws IOException {
+
+      if(shardBoundary == ShardBoundary.STRICT) {
+        // TODO: When this is supported server-side, instead verify that request.getIntersectionType
+        // will yield a strict shard.
+        shardPredicate = new Predicate<Read>() {
+          @Override
+          public boolean apply(Read read) {
+            return read.getAlignment().getPosition().getPosition() >= request.getStart();
+          }
+        };
+      }
+
       return api.search(pageToken
           .transform(
               new Function<String, SearchReadsRequest>() {
@@ -419,6 +437,9 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
     }
 
     @Override Iterable<Read> getResponses(SearchReadsResponse response) {
+      if(shardPredicate != null) {
+        return Iterables.filter(response.getAlignments(), shardPredicate);
+      }
       return response.getAlignments();
     }
   }
@@ -704,8 +725,16 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
     /**
      * Static factory method.
      *
+     * The variants search API by default returns all variants that overlap the specified range.
+     * Ranges are half-open 0-based, so [start,end)
+     *
+     * Cluster compute jobs attempting to shard the data will see any records that span a shard
+     * boundary in both shards. In some cases this might be okay, in others it is not.
+     * 
      * @param genomics The {@link Genomics} stub.
-     * @return the new paginator.
+     * @param shardBoundary Use ShardBoundary.OVERLAPS for the default behavior or use
+     *        ShardBoundary.STRICT to ensure that a record does not appear in more than one shard.
+     * @return
      */
     public static Variants create(Genomics genomics, ShardBoundary shardBoundary) {
       return new Variants(genomics, shardBoundary);
@@ -719,7 +748,9 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
     @Override Genomics.Variants.Search createSearch(Genomics.Variants api,
         final SearchVariantsRequest request, Optional<String> pageToken) throws IOException {
       
-      if(shardBoundary == ShardBoundary.STARTS_IN) {
+      if(shardBoundary == ShardBoundary.STRICT) {
+        // TODO: When this is supported server-side, instead verify that request.getIntersectionType
+        // will yield a strict shard.
         shardPredicate = new Predicate<Variant>() {
           @Override
           public boolean apply(Variant variant) {

--- a/src/test/java/com/google/cloud/genomics/utils/PaginatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/PaginatorTest.java
@@ -16,9 +16,14 @@
 package com.google.cloud.genomics.utils;
 
 import com.google.api.services.genomics.Genomics;
+import com.google.api.services.genomics.model.LinearAlignment;
+import com.google.api.services.genomics.model.Position;
+import com.google.api.services.genomics.model.Read;
 import com.google.api.services.genomics.model.ReadGroupSet;
 import com.google.api.services.genomics.model.SearchReadGroupSetsRequest;
 import com.google.api.services.genomics.model.SearchReadGroupSetsResponse;
+import com.google.api.services.genomics.model.SearchReadsRequest;
+import com.google.api.services.genomics.model.SearchReadsResponse;
 import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.api.services.genomics.model.SearchVariantsResponse;
 import com.google.api.services.genomics.model.Variant;
@@ -49,12 +54,15 @@ public class PaginatorTest {
   @Mock Genomics.Readgroupsets.Search readGroupSetSearch;
   @Mock Genomics.Variants variants;
   @Mock Genomics.Variants.Search variantsSearch;
+  @Mock Genomics.Reads reads;
+  @Mock Genomics.Reads.Search readsSearch;
 
   @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
     Mockito.when(genomics.readgroupsets()).thenReturn(readGroupSets);
     Mockito.when(genomics.variants()).thenReturn(variants);
+    Mockito.when(genomics.reads()).thenReturn(reads);
   }
 
   @Test
@@ -134,7 +142,7 @@ public class PaginatorTest {
     Variant overlapStartExtent = new Variant().setStart(999L).setEnd(5000L);
     Variant atStartWithinExtent = new Variant().setStart(1000L).setEnd(1002L);
     Variant atStartOverlapExtent = new Variant().setStart(1000L).setEnd(5000L);
-    Variant beyondStartWithinExtent = new Variant().setStart(1500L).setEnd(1002L);
+    Variant beyondStartWithinExtent = new Variant().setStart(1500L).setEnd(1502L);
     Variant beyondOverlapExtent = new Variant().setStart(1500L).setEnd(5000L);
     Variant[] input = new Variant[] { overlapStartWithinExtent, overlapStartExtent, atStartWithinExtent,
             atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent };
@@ -142,7 +150,7 @@ public class PaginatorTest {
     Mockito.when(variantsSearch.execute()).thenReturn(
         new SearchVariantsResponse().setVariants(Arrays.asList(input)));
 
-    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.STARTS_IN);
+    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.STRICT);
     List<Variant> filteredVariants = Lists.newArrayList();
     for (Variant variant : filteredPaginator.search(request)) {
       filteredVariants.add(variant);
@@ -158,6 +166,49 @@ public class PaginatorTest {
     }
     assertEquals(6, overlappingVariants.size());
     assertThat(overlappingVariants, CoreMatchers.hasItems(input));
+  }
+  
+  
+  Read readHelper(int start, int end) {
+    Position position = new Position().setPosition((long) start);
+    LinearAlignment alignment = new LinearAlignment().setPosition(position);
+    return new Read().setAlignment(alignment).setFragmentLength(end-start);
+  }
+  
+  @Test
+  public void testReadPagination() throws Exception {
+
+    SearchReadsRequest request = new SearchReadsRequest().setStart(1000L).setEnd(2000L);
+    Mockito.when(reads.search(request)).thenReturn(readsSearch);
+
+    Read overlapStartWithinExtent = readHelper(900,1005);
+    Read overlapStartExtent = readHelper(999, 5000);
+    Read atStartWithinExtent = readHelper(1000, 1002);
+    Read atStartOverlapExtent = readHelper(1000, 5000);
+    Read beyondStartWithinExtent = readHelper(1500, 1502);
+    Read beyondOverlapExtent = readHelper(1500, 5000);
+    Read[] input = new Read[] { overlapStartWithinExtent, overlapStartExtent, atStartWithinExtent,
+            atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent };
+
+    Mockito.when(readsSearch.execute()).thenReturn(
+        new SearchReadsResponse().setAlignments(Arrays.asList(input)));
+
+    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.STRICT);
+    List<Read> filteredReads = Lists.newArrayList();
+    for (Read read : filteredPaginator.search(request)) {
+      filteredReads.add(read);
+    }
+    assertEquals(4, filteredReads.size());
+    assertThat(filteredReads, CoreMatchers.hasItems(atStartWithinExtent,
+        atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent));
+
+    Paginator.Reads overlappingPaginator = Paginator.Reads.create(genomics, ShardBoundary.OVERLAPS);
+    List<Read> overlappingReads = Lists.newArrayList();
+    for (Read read : overlappingPaginator.search(request)) {
+      overlappingReads.add(read);
+    }
+    assertEquals(6, overlappingReads.size());
+    assertThat(overlappingReads, CoreMatchers.hasItems(input));
   }
   
 }

--- a/src/test/java/com/google/cloud/genomics/utils/PaginatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/PaginatorTest.java
@@ -19,7 +19,13 @@ import com.google.api.services.genomics.Genomics;
 import com.google.api.services.genomics.model.ReadGroupSet;
 import com.google.api.services.genomics.model.SearchReadGroupSetsRequest;
 import com.google.api.services.genomics.model.SearchReadGroupSetsResponse;
+import com.google.api.services.genomics.model.SearchVariantsRequest;
+import com.google.api.services.genomics.model.SearchVariantsResponse;
+import com.google.api.services.genomics.model.Variant;
+import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
 import com.google.common.collect.Lists;
+
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,9 +34,11 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
@@ -39,11 +47,14 @@ public class PaginatorTest {
   @Mock Genomics genomics;
   @Mock Genomics.Readgroupsets readGroupSets;
   @Mock Genomics.Readgroupsets.Search readGroupSetSearch;
+  @Mock Genomics.Variants variants;
+  @Mock Genomics.Variants.Search variantsSearch;
 
   @Before
   public void initMocks() {
     MockitoAnnotations.initMocks(this);
     Mockito.when(genomics.readgroupsets()).thenReturn(readGroupSets);
+    Mockito.when(genomics.variants()).thenReturn(variants);
   }
 
   @Test
@@ -113,4 +124,40 @@ public class PaginatorTest {
     Mockito.verify(readGroupSetSearch, Mockito.atLeastOnce()).setFields("readGroupSets(id,name)");
   }
 
+  @Test
+  public void testVariantPagination() throws Exception {
+
+    SearchVariantsRequest request = new SearchVariantsRequest().setStart(1000L).setEnd(2000L);
+    Mockito.when(variants.search(request)).thenReturn(variantsSearch);
+
+    Variant overlapStartWithinExtent = new Variant().setStart(900L).setEnd(1005L);
+    Variant overlapStartExtent = new Variant().setStart(999L).setEnd(5000L);
+    Variant atStartWithinExtent = new Variant().setStart(1000L).setEnd(1002L);
+    Variant atStartOverlapExtent = new Variant().setStart(1000L).setEnd(5000L);
+    Variant beyondStartWithinExtent = new Variant().setStart(1500L).setEnd(1002L);
+    Variant beyondOverlapExtent = new Variant().setStart(1500L).setEnd(5000L);
+    Variant[] input = new Variant[] { overlapStartWithinExtent, overlapStartExtent, atStartWithinExtent,
+            atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent };
+
+    Mockito.when(variantsSearch.execute()).thenReturn(
+        new SearchVariantsResponse().setVariants(Arrays.asList(input)));
+
+    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.STARTS_IN);
+    List<Variant> filteredVariants = Lists.newArrayList();
+    for (Variant variant : filteredPaginator.search(request)) {
+      filteredVariants.add(variant);
+    }
+    assertEquals(4, filteredVariants.size());
+    assertThat(filteredVariants, CoreMatchers.hasItems(atStartWithinExtent,
+        atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent));
+
+    Paginator.Variants overlappingPaginator = Paginator.Variants.create(genomics, ShardBoundary.OVERLAPS);
+    List<Variant> overlappingVariants = Lists.newArrayList();
+    for (Variant variant : overlappingPaginator.search(request)) {
+      overlappingVariants.add(variant);
+    }
+    assertEquals(6, overlappingVariants.size());
+    assertThat(overlappingVariants, CoreMatchers.hasItems(input));
+  }
+  
 }


### PR DESCRIPTION
Prior to this change, cluster compute jobs attempting to shard the variants data will see any records that span a shard boundary in both shards.  In some cases this might be okay, in others it is not.

Also changed the filter parameter in getContigsInVariantSet from a boolean to an enum to indicate its behavior.