### PR TITLE
Undoing my messed up version release so I can start over.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.google.cloud.genomics</groupId>
   <artifactId>google-genomics-utils</artifactId>
   <packaging>jar</packaging>
-  <version>v1beta2-0.29-SNAPSHOT</version>
+  <version>v1beta2-0.28-SNAPSHOT</version>
 
   <organization>
     <name>Google</name>


### PR DESCRIPTION
This reverts commit 587bf079beac16e66bcd201028d0474b7f963e19.

Revert "[maven-release-plugin] prepare release google-genomics-utils-v1beta2-0.28"

This reverts commit 462e8feaf26455bf6c49d1d127f7032f874a113a.