### PR TITLE
Configure Travis CI to check java8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+
 install: /bin/true  # Don't run "gradle assemble" (which is the default)
 
 script: mvn test javadoc:javadoc


### PR DESCRIPTION
This will catch javadoc lint issues at pull request time.

See also https://github.com/googlegenomics/dataflow-java/issues/109