### PR TITLE
Refactor genomic range sharing into utils-java.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ settings.xml
 .classpath
 .settings
 
+.Rproj.user

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,23 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
+      <!-- adds "mvn verify" command to run the integration tests (any test ending in IT or ITCase). -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.18.1</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>

--- a/src/main/java/com/google/cloud/genomics/utils/Contig.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Contig.java
@@ -15,11 +15,18 @@
  */
 package com.google.cloud.genomics.utils;
 
-import com.google.api.services.genomics.Genomics;
-import com.google.api.services.genomics.model.ReferenceBound;
+import static com.google.common.base.Objects.equal;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import com.google.api.services.genomics.model.SearchReadsRequest;
 import com.google.api.services.genomics.model.SearchVariantsRequest;
-import com.google.api.services.genomics.model.VariantSet;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -27,35 +34,12 @@ import com.google.common.collect.Lists;
 import com.google.genomics.v1.StreamReadsRequest;
 import com.google.genomics.v1.StreamVariantsRequest;
 
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static com.google.common.base.Objects.equal;
-import static com.google.common.collect.Lists.newArrayList;
-import static java.util.Objects.hash;
-import static java.util.Objects.requireNonNull;
-
 /**
- * This class encapsulates logic regarding genomic regions.
- *
- * It includes utility methods for sharding those regions appropriately
- * for use in parallel processing pipelines and for creating request
- * objects from those shards.
- *
+ * A Contig is a contiguous region of the genome.
  */
 public class Contig implements Serializable {
 
   private static final long serialVersionUID = -1730387112193404207L;
-
-  public static final long DEFAULT_NUMBER_OF_BASES_PER_SHARD = 1000000;
-
-  public enum SexChromosomeFilter { INCLUDE_XY, EXCLUDE_XY }
-  
-  // If not running all contigs, we default to BRCA1
-  public static final String BRCA1 = "17:41196311:41277499";
 
   public final String referenceName;
   public final long start;
@@ -85,66 +69,17 @@ public class Contig implements Serializable {
     return referenceName + ':' + start + ':' + end;
   }
 
-  public SearchVariantsRequest getVariantsRequest(String variantSetId) {
-    return new SearchVariantsRequest()
-        .setVariantSetIds(Collections.singletonList(variantSetId))
-        .setReferenceName(referenceName)
-        .setStart(start)
-        .setEnd(end);
-  }
-
-  public StreamVariantsRequest getStreamVariantsRequest(String variantSetId) {
-    return StreamVariantsRequest.newBuilder()
-        .setVariantSetId(variantSetId)
-        .setReferenceName(referenceName)
-        .setStart(start)
-        .setEnd(end)
-        .build();
-  }
-
-  public SearchReadsRequest getReadsRequest(String readGroupSetId) {
-    return new SearchReadsRequest()
-        .setReadGroupSetIds(Collections.singletonList(readGroupSetId))
-        .setReferenceName(referenceName)
-        .setStart(start)
-        .setEnd(end);
-  }
-
-  public StreamReadsRequest getStreamReadsRequest(String readGroupSetId) {
-    return StreamReadsRequest.newBuilder()
-        .setReadGroupSetId(readGroupSetId)
-        .setReferenceName(referenceName)
-        .setStart(start)
-        .setEnd(end)
-        .build();
-  }
-
-  private List<Contig> getShards() {
-    return getShards(DEFAULT_NUMBER_OF_BASES_PER_SHARD);
-  }
-
-  // This is private because the static methods to determine shards should be used
-  // to ensure that they are shuffled all together before being returned to clients.
-  private List<Contig> getShards(long numberOfBasesPerShard) {
-    double shardCount = Math.ceil(end - start) / (double) numberOfBasesPerShard;
-    List<Contig> shards = Lists.newArrayList();
-    for (int i = 0; i < shardCount; i++) {
-      long shardStart = start + (i * numberOfBasesPerShard);
-      long shardEnd = Math.min(end, shardStart + numberOfBasesPerShard);
-
-      shards.add(new Contig(referenceName, shardStart, shardEnd));
-    }
-    return shards;
-  }
 
   /**
-   * Parse the list of Contigs expressed in the command line argument.
+   * Parse the list of Contigs expressed in the string argument.
    * 
-   * @param contigsArgument - the command line parameter expressing the specified genomic regions
-   *                            format is chromosome:start:end[,chromosome:start:end]
-   * @return a list of contigs
+   * The common use case is to parse the value of a command line parameter.
+   * 
+   * @param contigsArgument - a string expressing the specified contiguous region(s) of the genome.
+   *                          The format is chromosome:start:end[,chromosome:start:end]
+   * @return a list of Contig objects
    */
-  public static Iterable<Contig> parseContigsFromCommandLine(final String contigsArgument) {
+  public static Iterable<Contig> parseContigsFromCommandLine(String contigsArgument) {
     return Iterables.transform(Splitter.on(",").split(contigsArgument),
         new Function<String, Contig>() {
           @Override
@@ -155,107 +90,57 @@ public class Contig implements Serializable {
           }
         });
   }
+  
+  // The following methods have package scope and are helpers for ShardUtils. For sharded Contigs,
+  // the ShardUtils methods should be used to ensure that shards are shuffled all together before
+  // being returned to clients.
+  List<Contig> getShards(long numberOfBasesPerShard) {
+    double shardCount = Math.ceil(end - start) / (double) numberOfBasesPerShard;
+    List<Contig> shards = Lists.newArrayList();
+    for (int i = 0; i < shardCount; i++) {
+      long shardStart = start + (i * numberOfBasesPerShard);
+      long shardEnd = Math.min(end, shardStart + numberOfBasesPerShard);
 
-  /**
-   * Retrieve the list of all the reference names and their start/end positions for the variant set.
-   * 
-   * @param genomics - The {@link Genomics} stub.
-   * @param variantSetId - The id of the variant set to query.
-   * @param sexChromosomeFilter - An enum value indicating how sex chromosomes should be
-   *        handled in the result.
-   * @return The list of all references in the variant set.
-   * @throws IOException
-   */
-  public static List<Contig> getContigsInVariantSet(Genomics genomics, String variantSetId,
-      SexChromosomeFilter sexChromosomeFilter) throws IOException {
-    List<Contig> contigs = Lists.newArrayList();
-
-    VariantSet variantSet = genomics.variantsets().get(variantSetId).execute();
-    for (ReferenceBound bound : variantSet.getReferenceBounds()) {
-      String contig = bound.getReferenceName().toLowerCase();
-      if (sexChromosomeFilter == SexChromosomeFilter.EXCLUDE_XY
-          && (contig.contains("x") || contig.contains("y"))) {
-        // X and Y can skew some analysis results
-        continue;
-      }
-
-      contigs.add(new Contig(bound.getReferenceName(), 0, bound.getUpperBound()));
+      shards.add(new Contig(referenceName, shardStart, shardEnd));
     }
-
-    return contigs;
+    return shards;
   }
   
-  /**
-   * Get a list of Contigs representing sharded windows of all genomic regions within the variant set.
-   * 
-   * These are useful for pipelines that operate in parallel against data within a specific variant set.
-   * 
-   * @param genomics - the genomics client
-   * @param variantSetId - the id of the variant set for which to create shards
-   * @param sexChromosomeFilter - whether or not to include the sex chromosomes in the list of shards
-   * @return a shuffled list of shards
-   * @throws IOException
-   */
-  public static List<Contig> getAllShardsInVariantSet(final Genomics genomics, final String variantSetId,
-      final SexChromosomeFilter sexChromosomeFilter) throws IOException {
-    return getAllShardsInVariantSet(genomics, variantSetId, sexChromosomeFilter, DEFAULT_NUMBER_OF_BASES_PER_SHARD); 
-  }
-  
-  /**
-   * Get a list of Contigs representing sharded windows of all genomic regions within the variant set.
-   * 
-   * These are useful for pipelines that operate in parallel against data within a specific variant set.
-   * 
-   * @param genomics - the genomics client
-   * @param variantSetId - the id of the variant set for which to create shards
-   * @param sexChromosomeFilter - whether or not to include the sex chromosomes in the list of shards
-   * @param numberOfBasesPerShard - the maximum size of the shard window in terms of number of bases
-   * @return a shuffled list of shards
-   * @throws IOException
-   */
-  public static List<Contig> getAllShardsInVariantSet(final Genomics genomics, final String variantSetId,
-      final SexChromosomeFilter sexChromosomeFilter, final long numberOfBasesPerShard) throws IOException {
-    List<Contig> contigs = getContigsInVariantSet(genomics, variantSetId, sexChromosomeFilter);
-    return getAllShardsForContigs(contigs, numberOfBasesPerShard);
-  }
-  
-  /**
-   * Get a list of Contigs representing sharded windows of the specified genomic regions expressed in the command line argument.
-   * 
-   * These are useful for pipelines that operate in parallel against data within a specific variant set or read group set.
-   * 
-   * @param contigsArgument - the command line parameter expressing the specified genomic regions
-   *                            format is chromosome:start:end[,chromosome:start:end]
-   * @return a shuffled list of shards
-   */
-  public static List<Contig> getSpecifiedShards(final String contigsArgument) {
-    return getSpecifiedShards(contigsArgument, DEFAULT_NUMBER_OF_BASES_PER_SHARD);
+  @Deprecated // Remove this when fully migrated to gRPC.
+  SearchVariantsRequest getSearchVariantsRequest(String variantSetId) {
+    return new SearchVariantsRequest()
+        .setVariantSetIds(Collections.singletonList(variantSetId))
+        .setReferenceName(referenceName)
+        .setStart(start)
+        .setEnd(end);
   }
 
-  /**
-   * Get a list of Contigs representing sharded windows of the specified genomic regions expressed in the command line argument.
-   * 
-   * These are useful for pipelines that operate in parallel against data within a specific variant set or read group set.
-   * 
-   * @param contigsArgument - the command line parameter expressing the specified genomic regions
-   *                            format is chromosome:start:end[,chromosome:start:end]
-   * @param numberOfBasesPerShard - the maximum size of the shard window in terms of number of bases
-   * @return a shuffled list of shards
-   */
-  public static List<Contig> getSpecifiedShards(final String contigsArgument, final long numberOfBasesPerShard) {
-    Iterable<Contig> contigs = parseContigsFromCommandLine(contigsArgument);
-    return getAllShardsForContigs(contigs, numberOfBasesPerShard);
+  StreamVariantsRequest getStreamVariantsRequest(String variantSetId) {
+    return StreamVariantsRequest.newBuilder()
+        .setVariantSetId(variantSetId)
+        .setReferenceName(referenceName)
+        .setStart(start)
+        .setEnd(end)
+        .build();
   }
 
-  private static List<Contig> getAllShardsForContigs(Iterable<Contig> contigs, long numberOfBasesPerShard) {
-    List<Contig> shardedContigs = Lists.newArrayList();
-    for (Contig contig : contigs) {
-      shardedContigs.addAll(contig.getShards(numberOfBasesPerShard));
-    }
-    // IMPORTANT: Shuffle shards for better backend performance.
-    Collections.shuffle(shardedContigs);
-    return shardedContigs;
+  @Deprecated // Remove this when fully migrated to gRPC.
+  SearchReadsRequest getSearchReadsRequest(String readGroupSetId) {
+    return new SearchReadsRequest()
+        .setReadGroupSetIds(Collections.singletonList(readGroupSetId))
+        .setReferenceName(referenceName)
+        .setStart(start)
+        .setEnd(end);
   }
-  
+
+  StreamReadsRequest getStreamReadsRequest(String readGroupSetId) {
+    return StreamReadsRequest.newBuilder()
+        .setReadGroupSetId(readGroupSetId)
+        .setReferenceName(referenceName)
+        .setStart(start)
+        .setEnd(end)
+        .build();
+  }
+
 }
 

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
@@ -174,7 +174,7 @@ public class GenomicsFactory {
      * The number of times to retry a failed request to the Genomics API.
      *  
      * @param numRetries
-     * @return
+     * @return this
      */
     public Builder setNumberOfRetries(int numRetries) {
       this.numRetries = numRetries;

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
@@ -1,0 +1,89 @@
+package com.google.cloud.genomics.utils;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import com.google.api.services.genomics.Genomics;
+import com.google.api.services.genomics.model.CallSet;
+import com.google.api.services.genomics.model.ReadGroupSet;
+import com.google.api.services.genomics.model.ReferenceBound;
+import com.google.api.services.genomics.model.SearchCallSetsRequest;
+import com.google.api.services.genomics.model.SearchReadGroupSetsRequest;
+import com.google.api.services.genomics.model.SearchVariantSetsRequest;
+import com.google.api.services.genomics.model.VariantSet;
+import com.google.common.collect.Lists;
+
+/**
+ * Convenience routines for fetching ids in the hierarchy of data within the Genomics API and other data lookups.
+ */
+public class GenomicsUtils {
+  
+  /**
+   * Gets ReadGroupSetIds from a given datasetId using the Genomics API.
+   */
+  public static List<String> getReadGroupSetIds(String datasetId, GenomicsFactory.OfflineAuth auth)
+      throws IOException, GeneralSecurityException {
+    List<String> output = Lists.newArrayList();
+    Iterable<ReadGroupSet> rgs = Paginator.ReadGroupSets.create(
+        auth.getGenomics(auth.getDefaultFactory()))
+        .search(new SearchReadGroupSetsRequest().setDatasetIds(Lists.newArrayList(datasetId)),
+            "readGroupSets/id,nextPageToken");
+    for (ReadGroupSet r : rgs) {
+      output.add(r.getId());
+    }
+    if (output.isEmpty()) {
+      throw new IOException("Dataset " + datasetId + " does not contain any ReadGroupSets");
+    }
+    return output;
+  }
+  
+  /**
+   * Gets VariantSetIds from a given datasetId using the Genomics API.
+   */
+  public static List<String> getVariantSetIds(String datasetId, GenomicsFactory.OfflineAuth auth)
+      throws IOException, GeneralSecurityException {
+    List<String> output = Lists.newArrayList();
+    Iterable<VariantSet> vs = Paginator.Variantsets.create(
+        auth.getGenomics(auth.getDefaultFactory()))
+        .search(new SearchVariantSetsRequest().setDatasetIds(Lists.newArrayList(datasetId)),
+            "variantSets/id,nextPageToken");
+    for (VariantSet v : vs) {
+      output.add(v.getId());
+    }
+    if (output.isEmpty()) {
+      throw new IOException("Dataset " + datasetId + " does not contain any VariantSets");
+    }
+    return output;
+  }
+  
+  /**
+   * Gets CallSets Names for a given variantSetId using the Genomics API.
+   */
+  public static List<String> getCallSetsNames(String variantSetId, GenomicsFactory.OfflineAuth auth)
+      throws IOException, GeneralSecurityException {
+    List<String> output = Lists.newArrayList();
+    Iterable<CallSet> cs = Paginator.Callsets.create(
+        auth.getGenomics(auth.getDefaultFactory()))
+        .search(new SearchCallSetsRequest().setVariantSetIds(Lists.newArrayList(variantSetId)),
+            "callSets/name,nextPageToken");
+    for (CallSet c : cs) {
+      output.add(c.getName());
+    }
+    if (output.isEmpty()) {
+      throw new IOException("VariantSet " + variantSetId + " does not contain any CallSets");
+    }
+    return output;
+  }
+
+  /**
+   * Gets the ReferenceBounds for a given variantSetId using the Genomics API.
+   */
+  public static List<ReferenceBound> getReferenceBounds(String variantSetId, GenomicsFactory.OfflineAuth auth)
+      throws IOException, GeneralSecurityException {
+    Genomics genomics = auth.getGenomics(auth.getDefaultFactory());
+    VariantSet variantSet = genomics.variantsets().get(variantSetId).execute();
+    return variantSet.getReferenceBounds();
+  }
+
+}

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
@@ -21,6 +21,12 @@ public class GenomicsUtils {
   
   /**
    * Gets ReadGroupSetIds from a given datasetId using the Genomics API.
+   *
+   * @param datasetId The id of the dataset to query.
+   * @param auth The OfflineAuth for the API request.
+   * @return The list of readGroupSetIds in the dataset.
+   * @throws IOException If dataset does not contain any readGroupSets.
+   * @throws GeneralSecurityException
    */
   public static List<String> getReadGroupSetIds(String datasetId, GenomicsFactory.OfflineAuth auth)
       throws IOException, GeneralSecurityException {
@@ -40,6 +46,12 @@ public class GenomicsUtils {
   
   /**
    * Gets VariantSetIds from a given datasetId using the Genomics API.
+   *
+   * @param datasetId The id of the dataset to query.
+   * @param auth The OfflineAuth for the API request.
+   * @return The list of variantSetIds in the dataset.
+   * @throws IOException If dataset does not contain any variantSets.
+   * @throws GeneralSecurityException
    */
   public static List<String> getVariantSetIds(String datasetId, GenomicsFactory.OfflineAuth auth)
       throws IOException, GeneralSecurityException {
@@ -59,6 +71,13 @@ public class GenomicsUtils {
   
   /**
    * Gets CallSets Names for a given variantSetId using the Genomics API.
+   * 
+   * @param variantSetId The id of the variantSet to query.
+   * @param auth The OfflineAuth for the API request.
+   * @return The list of callSet names in the variantSet.
+   * @throws IOException If variantSet does not contain any CallSets.
+   * @throws GeneralSecurityException
+
    */
   public static List<String> getCallSetsNames(String variantSetId, GenomicsFactory.OfflineAuth auth)
       throws IOException, GeneralSecurityException {
@@ -78,6 +97,12 @@ public class GenomicsUtils {
 
   /**
    * Gets the ReferenceBounds for a given variantSetId using the Genomics API.
+   *
+   * @param variantSetId The id of the variantSet to query.
+   * @param auth The OfflineAuth for the API request.
+   * @return The list of reference bounds in the variantSet.
+   * @throws IOException
+   * @throws GeneralSecurityException
    */
   public static List<ReferenceBound> getReferenceBounds(String variantSetId, GenomicsFactory.OfflineAuth auth)
       throws IOException, GeneralSecurityException {

--- a/src/main/java/com/google/cloud/genomics/utils/Paginator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Paginator.java
@@ -94,9 +94,9 @@ import com.google.common.collect.Maps;
  *String datasetId = ...;
  *Paginator.Readsets searchReadsets = Paginator.Readsets.create(stub);
  *for (Readset readset =
- *    searchReadsets.search(new SearchReadsetsRequest().setDatasetId(datasetId))) {
+ *    searchReadsets.search(new SearchReadsetsRequest().setDatasetId(datasetId))) &#123;
  *  // do something with readset
- *}
+ *&#125;
  *}
  *</pre>
  *

--- a/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
@@ -1,0 +1,297 @@
+package com.google.cloud.genomics.utils;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.api.services.genomics.model.ReferenceBound;
+import com.google.api.services.genomics.model.SearchReadsRequest;
+import com.google.api.services.genomics.model.SearchVariantsRequest;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamVariantsRequest;
+
+/**
+ * Utility methods for creating sharded reads or variants request objects from contiguous
+ * region of the genome for use in parallel processing pipelines.
+ * 
+ * DEV NOTE: Sharding can be tricky to get right.
+ *  - Shuffling of shards is important for good request distribution.
+ *  - The actual amount of data within each API shard can vary greatly per dataset.
+ *  - Shard sizing is important.
+ *  --- Shards that are very small are inefficient.
+ *  --- Shards need to be retried (e.g., due to temporary network issues) result in
+ *      large quantities of repeated work if they are too big.
+ *  - The total number of shards is important.
+ *  --- If we have fewer than the number of threads/core available, resources
+ *      may be underutilized.
+ *  --- If we have just a few more shards than the number of threads/core available,
+ *      resources may be underutilized.
+ *  --- If we have too many, depending on the algorithm, the amount of data to
+ *      be shuffled for the next step could be quite large, if a combiner is not used.
+ *  - Shard strategies can also differ based on paginated vs. streaming APIs.
+ *  
+ * This is clearly a work in progress, many of the issues described above are not addressed
+ * in the code below.  But let's consolidate the tribal knowledge here for best practices
+ * in manual sharding for reuse by Spark or any other systems processing data in parallel.
+ * 
+ * For Dataflow, custom sources should be preferred over this manual sharding approach.
+ *
+ */
+public class ShardUtils {
+
+  /**
+   * Some analyses should not include data from the sex chromosomes.
+   */
+  public enum SexChromosomeFilter { 
+    /**
+     * Include data from the sex chromosomes in the shards.
+     */
+    INCLUDE_XY,
+    /**
+     * Exclude data from the sex chromosomes from the shards.
+     */
+    EXCLUDE_XY
+    }
+
+  /**
+   * Constructs sharded StreamVariantsRequests for the specified contiguous region(s) of the genome.
+   * 
+   * @param variantSetId The variantSetId.
+   * @param references The specified contiguous region(s) of the genome.
+   * @param numberOfBasesPerShard The maximum number of bases to include per shard.
+   * @return The shuffled list of sharded request objects.
+   */
+  public static ImmutableList<StreamVariantsRequest> getVariantRequests(final String variantSetId,
+      String references, long numberOfBasesPerShard) {
+    Iterable<Contig> shards = getSpecifiedShards(references, numberOfBasesPerShard);
+    return FluentIterable.from(shards)
+        .transform(new Function<Contig, StreamVariantsRequest>() {
+          @Override
+          public StreamVariantsRequest apply(Contig shard) {
+            return shard.getStreamVariantsRequest(variantSetId);
+          }
+        }).toList();
+  }
+
+  /**
+   * Constructs sharded SearchVariantsRequests for the specified contiguous region(s) of the genome.
+   * 
+   * @param variantSetId The variantSetId.
+   * @param references The specified contiguous region(s) of the genome.
+   * @param numberOfBasesPerShard The maximum number of bases to include per shard.
+   * @return The shuffled list of sharded request objects.
+   */
+  @Deprecated // Remove this when fully migrated to gRPC.
+  public static ImmutableList<SearchVariantsRequest> getPaginatedVariantRequests(final String variantSetId,
+      String references, long numberOfBasesPerShard) {
+    Iterable<Contig> shards = getSpecifiedShards(references, numberOfBasesPerShard);
+    return FluentIterable.from(shards)
+        .transform(new Function<Contig, SearchVariantsRequest>() {
+          @Override
+          public SearchVariantsRequest apply(Contig shard) {
+            return shard.getSearchVariantsRequest(variantSetId);
+          }
+        }).toList();
+  }
+  
+  /**
+   * Constructs sharded StreamVariantsRequests for the all references in the variantSet.
+   * 
+   * @param variantSetId The variantSetId.
+   * @param sexChromosomeFilter An enum value indicating how sex chromosomes should be
+   *        handled in the result.
+   * @param numberOfBasesPerShard The maximum number of bases to include per shard.
+   * @param auth The OfflineAuth to be used to get the reference bounds for the variantSet.
+   * @return The shuffled list of sharded request objects.
+   * @throws IOException 
+   * @throws GeneralSecurityException 
+   */
+  public static ImmutableList<StreamVariantsRequest> getVariantRequests(final String variantSetId,
+      SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
+      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+    Iterable<Contig> shards = getAllShardsInVariantSet(variantSetId,
+        sexChromosomeFilter, numberOfBasesPerShard, auth);
+    return FluentIterable.from(shards)
+        .transform(new Function<Contig, StreamVariantsRequest>() {
+          @Override
+          public StreamVariantsRequest apply(Contig shard) {
+            return shard.getStreamVariantsRequest(variantSetId);
+          }
+        }).toList();
+  }
+
+  /**
+   * Constructs sharded SearchVariantsRequests for the all references in the variantSet.
+   * 
+   * @param variantSetId The variantSetId.
+   * @param sexChromosomeFilter An enum value indicating how sex chromosomes should be
+   *        handled in the result.
+   * @param numberOfBasesPerShard The maximum number of bases to include per shard.
+   * @param auth The OfflineAuth to be used to get the reference bounds for the variantSet.
+   * @return The shuffled list of sharded request objects.
+   * @throws IOException 
+   * @throws GeneralSecurityException 
+   */
+  @Deprecated // Remove this when fully migrated to gRPC.
+  public static ImmutableList<SearchVariantsRequest> getPaginatedVariantRequests(final String variantSetId,
+      SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
+      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+    Iterable<Contig> shards = getAllShardsInVariantSet(variantSetId,
+        sexChromosomeFilter, numberOfBasesPerShard, auth);
+    return FluentIterable.from(shards)
+        .transform(new Function<Contig, SearchVariantsRequest>() {
+          @Override
+          public SearchVariantsRequest apply(Contig shard) {
+            return shard.getSearchVariantsRequest(variantSetId);
+          }
+        }).toList();
+  }
+  
+  /**
+   * Constructs sharded StreamReadsRequests for the specified contiguous region(s) of the genome.
+   * 
+   * @param readGroupSetIds The list of readGroupSetIds.
+   * @param references The specified contiguous region(s) of the genome.
+   * @param numberOfBasesPerShard The maximum number of bases to include per shard.
+   * @return The shuffled list of sharded request objects.
+   */
+  public static ImmutableList<StreamReadsRequest> getReadRequests(List<String> readGroupSetIds,
+      String references, long numberOfBasesPerShard) {
+    final Iterable<Contig> shards = getSpecifiedShards(references, numberOfBasesPerShard);
+
+    // Work around lack of FluentIterable.shuffle() https://github.com/google/guava/issues/1358
+    List<StreamReadsRequest> requests =
+        Arrays.asList(FluentIterable.from(readGroupSetIds)
+        .transformAndConcat(new Function<String, Iterable<StreamReadsRequest>>() {
+          @Override
+          public Iterable<StreamReadsRequest> apply(final String readGroupSetId) {
+            return FluentIterable.from(shards)
+                .transform(new Function<Contig, StreamReadsRequest>() {
+                  @Override
+                  public StreamReadsRequest apply(Contig shard) {
+                    return shard.getStreamReadsRequest(readGroupSetId);
+                  }
+                });
+          }
+        }).toArray(StreamReadsRequest.class));
+    // The shards were already shuffled, but now lets shuffle this list of concatenated shuffled requests.
+    Collections.shuffle(requests);
+    return FluentIterable.from(requests).toList();
+  }
+
+  /**
+   * Constructs sharded SearchReadsRequests for the specified contiguous region(s) of the genome.
+   * 
+   * @param readGroupSetIds The list of readGroupSetIds.
+   * @param references The specified contiguous region(s) of the genome.
+   * @param numberOfBasesPerShard The maximum number of bases to include per shard.
+   * @return The shuffled list of sharded request objects.
+   */
+  @Deprecated // Remove this when fully migrated to gRPC.
+  public static ImmutableList<SearchReadsRequest> getPaginatedReadRequests(List<String> readGroupSetIds,
+      String references, long numberOfBasesPerShard) {
+    final Iterable<Contig> shards = getSpecifiedShards(references, numberOfBasesPerShard);
+
+    // Work around lack of FluentIterable.shuffle() https://github.com/google/guava/issues/1358
+   List<SearchReadsRequest> requests =
+        Arrays.asList(FluentIterable.from(readGroupSetIds)
+        .transformAndConcat(new Function<String, Iterable<SearchReadsRequest>>() {
+          @Override
+          public Iterable<SearchReadsRequest> apply(final String readGroupSetId) {
+            return FluentIterable.from(shards)
+                .transform(new Function<Contig, SearchReadsRequest>() {
+                  @Override
+                  public SearchReadsRequest apply(Contig shard) {
+                    return shard.getSearchReadsRequest(readGroupSetId);
+                  }
+                });
+          }
+        }).toArray(SearchReadsRequest.class));
+    // The shards were already shuffled, but now lets shuffle this list of concatenated shuffled requests.
+    Collections.shuffle(requests);
+    return FluentIterable.from(requests).toList();
+  }
+
+  /**
+   * Constructs StreamReadsRequest for the readGroupSetIds, assuming that the user wants to
+   * include all references.
+   * 
+   * TODO: Should this be sharded - by the referenceBounds for the associated referenceSet
+   *     and/or by read groups?
+   * 
+   * @param readGroupSetIds The readGroupSetIds.
+   * @return The shuffled list of sharded request objects.
+   */
+  public static ImmutableList<StreamReadsRequest> getReadRequests(List<String> readGroupSetIds) {
+    // Work around lack of FluentIterable.shuffle() https://github.com/google/guava/issues/1358
+    List<StreamReadsRequest> requests =
+        Arrays.asList(FluentIterable.from(readGroupSetIds)
+        .transform(new Function<String, StreamReadsRequest>() {
+          @Override
+          public StreamReadsRequest apply(String readGroupSetId) {
+            return StreamReadsRequest.newBuilder()
+                .setReadGroupSetId(readGroupSetId)
+                .build();
+          }
+        }).toArray(StreamReadsRequest.class));
+    Collections.shuffle(requests);
+    return FluentIterable.from(requests).toList();
+  }
+
+  /**
+   * Retrieve the list of all the reference names and their start=0/end positions for the variantSet.
+   * 
+   * Note that start is hardcoded to zero since the referenceBounds only include the upper bound. 
+   * 
+   * @param variantSetId - The id of the variantSet to query.
+   * @param sexChromosomeFilter - An enum value indicating how sex chromosomes should be
+   *        handled in the result.
+   * @return The list of all references in the variantSet.
+   * @throws IOException
+   * @throws GeneralSecurityException 
+   */
+  private static List<Contig> getContigsInVariantSet(String variantSetId,
+      SexChromosomeFilter sexChromosomeFilter, GenomicsFactory.OfflineAuth auth)
+          throws IOException, GeneralSecurityException {
+    List<Contig> contigs = Lists.newArrayList();
+    for (ReferenceBound bound : GenomicsUtils.getReferenceBounds(variantSetId, auth)) {
+      String contig = bound.getReferenceName().toLowerCase();
+      if (sexChromosomeFilter == SexChromosomeFilter.EXCLUDE_XY
+          && (contig.contains("x") || contig.contains("y"))) {
+        // X and Y can skew some analysis results
+        continue;
+      }
+      contigs.add(new Contig(bound.getReferenceName(), 0, bound.getUpperBound()));
+    }
+    return contigs;
+  }
+
+  private static List<Contig> getAllShardsInVariantSet(String variantSetId,
+      SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
+      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+    List<Contig> contigs = getContigsInVariantSet(variantSetId, sexChromosomeFilter, auth);
+    return ShardUtils.getAllShardsForContigs(contigs, numberOfBasesPerShard);
+  }
+
+  private static List<Contig> getSpecifiedShards(String contigsArgument, long numberOfBasesPerShard) {
+    Iterable<Contig> contigs = Contig.parseContigsFromCommandLine(contigsArgument);
+    return ShardUtils.getAllShardsForContigs(contigs, numberOfBasesPerShard);
+  }
+
+  private static List<Contig> getAllShardsForContigs(Iterable<Contig> contigs, long numberOfBasesPerShard) {
+    List<Contig> shardedContigs = Lists.newArrayList();
+    for (Contig contig : contigs) {
+      shardedContigs.addAll(contig.getShards(numberOfBasesPerShard));
+    }
+    // IMPORTANT: Shuffle shards for better backend performance.
+    Collections.shuffle(shardedContigs);
+    return shardedContigs;
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/ContigTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ContigTest.java
@@ -16,80 +16,48 @@
 package com.google.cloud.genomics.utils;
 
 import static com.google.common.collect.Lists.newArrayList;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
 import java.util.List;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import com.google.api.services.genomics.model.SearchReadsRequest;
 import com.google.api.services.genomics.model.SearchVariantsRequest;
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.collect.Ordering;
 
 @RunWith(JUnit4.class)
 public class ContigTest {
   
-  final Ordering<Contig> BY_REFERENCE_NAME = Ordering.natural().onResultOf(
-      new Function<Contig, String>() {
-        @Override
-        public String apply(Contig contig) {
-          return contig.referenceName;
-        }
-      });
-  final Ordering<Contig> BY_START = Ordering.natural().onResultOf(
-      new Function<Contig, Long>() {
-        @Override
-        public Long apply(Contig contig) {
-          return contig.start;
-        }
-      });    
-  final Ordering<Contig> BY_END = Ordering.natural().onResultOf(
-      new Function<Contig, Long>() {
-        @Override
-        public Long apply(Contig contig) {
-          return contig.end;
-        }
-      });
-  final Ordering<Contig> CONTIG_ORDERING = BY_REFERENCE_NAME.compound(BY_START.compound(BY_END));
-
-
   @Test
   public void testGetShards() throws Exception {
-    final Contig[] EXPECTED_RESULT = {
-      new Contig("chr1", 0, 50),
-      new Contig("chr1", 50, 100),
-      new Contig("chr1", 100, 150),
-      new Contig("chr2", 25, 75),
-      new Contig("chr2", 75, 125),
-      new Contig("chr2", 125, 175),
-      new Contig("chr2", 175, 225),
-      new Contig("chr2", 225, 250),
-    };
-    
-    List<Contig> shards = Contig.getSpecifiedShards("chr1:0:150,chr2:25:250", 50);
-    assertThat(shards, CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
-    
-    // Call it a second time, expect the same set of shards but in a different order.
-    List<Contig> shards2 = Contig.getSpecifiedShards("chr1:0:150,chr2:25:250", 50);
-    
-    assertThat(shards, is(not(shards2)));
-    Collections.sort(shards, CONTIG_ORDERING);
-    Collections.sort(shards2, CONTIG_ORDERING);
-    assertThat(shards, is(shards2));
-  }
+    Contig contig = new Contig("1", 0, 9);
+    List<Contig> shards = contig.getShards(5);
 
+    assertEquals(2, shards.size());
+    Contig shard1 = shards.get(0);
+    Contig shard2 = shards.get(1);
+
+    // The code shuffles the shard, so lets make sure that we test the right shards
+    if (shard1.start > shard2.start) {
+      shard1 = shards.get(1);
+      shard2 = shards.get(0);
+    }
+
+    assertEquals("1", shard1.referenceName);
+    assertEquals(0, shard1.start);
+    assertEquals(5, shard1.end);
+
+    assertEquals("1", shard2.referenceName);
+    assertEquals(5, shard2.start);
+    assertEquals(9, shard2.end);
+  }
+  
   @Test
   public void testGetVariantsRequest() throws Exception {
-    SearchVariantsRequest request = new Contig("1", 0, 9).getVariantsRequest("vs");
+    SearchVariantsRequest request = new Contig("1", 0, 9).getSearchVariantsRequest("vs");
     assertEquals("vs", request.getVariantSetIds().get(0));
     assertEquals("1", request.getReferenceName());
     assertEquals(0, request.getStart().longValue());
@@ -98,7 +66,7 @@ public class ContigTest {
 
   @Test
   public void testGetReadsRequest() throws Exception {
-    SearchReadsRequest request = new Contig("1", 0, 9).getReadsRequest("rs");
+    SearchReadsRequest request = new Contig("1", 0, 9).getSearchReadsRequest("rs");
     assertEquals("rs", request.getReadGroupSetIds().get(0));
     assertEquals("1", request.getReferenceName());
     assertEquals(0, request.getStart().longValue());

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class GenomicsUtilsITCase {
+  
+  static IntegrationTestHelper helper;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    helper = new IntegrationTestHelper();
+  }
+  
+  @Test
+  public void testGetReadGroupSetIds() throws IOException, GeneralSecurityException {
+    assertThat(GenomicsUtils.getReadGroupSetIds(helper.PLATINUM_GENOMES_DATASET, helper.auth),
+        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_READGROUPSETS))); 
+  }
+
+  @Test
+  public void testGetVariantSetIds() throws IOException, GeneralSecurityException {
+    assertThat(GenomicsUtils.getVariantSetIds(helper.PLATINUM_GENOMES_DATASET, helper.auth),
+        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_VARIANTSET))); 
+  }
+
+  @Test
+  public void testGetCallSetsNames() throws IOException, GeneralSecurityException {
+    assertThat(GenomicsUtils.getCallSetsNames(helper.PLATINUM_GENOMES_VARIANTSET, helper.auth),
+        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_CALLSET_NAMES))); 
+  }
+
+  @Test
+  public void testGetReferenceBounds() throws IOException, GeneralSecurityException {
+    assertThat(GenomicsUtils.getReferenceBounds(helper.PLATINUM_GENOMES_VARIANTSET, helper.auth),
+        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_VARIANTSET_BOUNDS))); 
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.junit.Assert;
+
+import com.google.api.services.genomics.model.ReferenceBound;
+import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
+
+/**
+ * Helpers for common tasks involved in integration tests against the Genomics API.
+ */
+public class IntegrationTestHelper {
+  // Test data constants
+  public static final String PLATINUM_GENOMES_DATASET = "3049512673186936334";
+  public static final int PLATINUM_GENOMES_NUMBER_OF_SAMPLES = 17;
+  public static final String PLATINUM_GENOMES_VARIANTSET = "3049512673186936334";
+  public static final String[] PLATINUM_GENOMES_CALLSET_NAMES = {
+    "NA12877",
+    "NA12893",
+    "NA12885",
+    "NA12889",
+    "NA12887",
+    "NA12881",
+    "NA12888",
+    "NA12882",
+    "NA12879",
+    "NA12891",
+    "NA12883",
+    "NA12892",
+    "NA12886",
+    "NA12890",
+    "NA12878",
+    "NA12884",
+    "NA12880",
+  };
+  public static final String[] PLATINUM_GENOMES_READGROUPSETS = {
+    "CMvnhpKTFhCAv6TKo6Dglgg",
+    "CMvnhpKTFhDw8e3V6aCB-Q8",
+    "CMvnhpKTFhDo08GNkfe-jxo",
+    "CMvnhpKTFhD3he72j4KZuyc",
+    "CMvnhpKTFhCIy4KD0qrtjzA",
+    "CMvnhpKTFhCyz5LDrZ7Jozs",
+    "CMvnhpKTFhDyy__v0qfPpkw",
+    "CMvnhpKTFhDIr8bKjdbdolc",
+    "CMvnhpKTFhC1m-r_6Omp5X0",
+    "CMvnhpKTFhCw5I3dqMq6mYMB",
+    "CMvnhpKTFhD_tKnl__-RqJwB",
+    "CMvnhpKTFhDLyY-4kYvurqsB",
+    "CMvnhpKTFhCoyJTFk73Eyq0B",
+    "CMvnhpKTFhDE9a7F7Yai2rAB",
+    "CMvnhpKTFhCUpIDDveWE-r0B",
+    "CMvnhpKTFhCrvIOEw4Ol__sB",
+  };
+  public static final String PLATINUM_GENOMES_BRCA1_REFERENCES = "chr17:41196311:41277499";
+  public static final ReferenceBound[] PLATINUM_GENOMES_VARIANTSET_BOUNDS = {
+    new ReferenceBound().setReferenceName("chr1").setUpperBound(250226910L),
+    new ReferenceBound().setReferenceName("chr10").setUpperBound(136466007L),
+    new ReferenceBound().setReferenceName("chr11").setUpperBound(135762137L),
+    new ReferenceBound().setReferenceName("chr12").setUpperBound(134049696L),
+    new ReferenceBound().setReferenceName("chr13").setUpperBound(115800144L),
+    new ReferenceBound().setReferenceName("chr14").setUpperBound(107857350L),
+    new ReferenceBound().setReferenceName("chr15").setUpperBound(103000009L),
+    new ReferenceBound().setReferenceName("chr16").setUpperBound(90760361L),
+    new ReferenceBound().setReferenceName("chr17").setUpperBound(81983044L),
+    new ReferenceBound().setReferenceName("chr18").setUpperBound(78776233L),
+    new ReferenceBound().setReferenceName("chr19").setUpperBound(59544813L),
+    new ReferenceBound().setReferenceName("chr2").setUpperBound(243800708L),
+    new ReferenceBound().setReferenceName("chr20").setUpperBound(62993757L),
+    new ReferenceBound().setReferenceName("chr21").setUpperBound(48724643L),
+    new ReferenceBound().setReferenceName("chr22").setUpperBound(51891601L),
+    new ReferenceBound().setReferenceName("chr3").setUpperBound(198316350L),
+    new ReferenceBound().setReferenceName("chr4").setUpperBound(191970744L),
+    new ReferenceBound().setReferenceName("chr5").setUpperBound(181054248L),
+    new ReferenceBound().setReferenceName("chr6").setUpperBound(171796962L),
+    new ReferenceBound().setReferenceName("chr7").setUpperBound(159737113L),
+    new ReferenceBound().setReferenceName("chr8").setUpperBound(147299246L),
+    new ReferenceBound().setReferenceName("chr9").setUpperBound(142027288L),
+    new ReferenceBound().setReferenceName("chrM").setUpperBound(1000001L),
+    new ReferenceBound().setReferenceName("chrX").setUpperBound(156231278L),
+    new ReferenceBound().setReferenceName("chrY").setUpperBound(60032946L)
+  };
+
+  // Test configuration constants
+  public final String API_KEY = System.getenv("GOOGLE_API_KEY");
+  public final OfflineAuth auth;
+  
+  public IntegrationTestHelper() throws IOException, GeneralSecurityException {
+    Assert.assertNotNull("You must set the GOOGLE_API_KEY environment variable for this test.", API_KEY);
+     auth = GenomicsFactory.builder("integration test").build().getOfflineAuthFromApiKey(API_KEY);
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
@@ -1,0 +1,111 @@
+package com.google.cloud.genomics.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter;
+import com.google.genomics.v1.StreamVariantsRequest;
+
+public class ShardUtilsITCase {
+
+  static IntegrationTestHelper helper;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    helper = new IntegrationTestHelper();
+  }
+
+  @Test
+  public void testGetVariantRequestsStringSexChromosomeFilterLongOfflineAuth() throws IOException, GeneralSecurityException {
+
+    StreamVariantsRequest[] EXPECTED_RESULT_XY = {
+        new Contig("chrX", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chrX", 150000000L, 156231278L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chrY", 0L, 60032946L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET)
+    };
+    
+    StreamVariantsRequest[] EXPECTED_RESULT = {
+        new Contig("chr1", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr1", 150000000L, 250226910L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr10", 0L, 136466007L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr11", 0L, 135762137L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr12", 0L, 134049696L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr13", 0L, 115800144L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr14", 0L, 107857350L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr15", 0L, 103000009L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr16", 0L, 90760361L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr17", 0L, 81983044L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr18", 0L, 78776233L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr19", 0L, 59544813L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr2", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr2", 150000000L, 243800708L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr20", 0L, 62993757L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr21", 0L, 48724643L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr22", 0L, 51891601L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr3", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr3", 150000000L, 198316350L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr4", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr4", 150000000L, 191970744L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr5", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr5", 150000000L, 181054248L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr6", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr6", 150000000L, 171796962L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr7", 0L, 150000000L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr7", 150000000L, 159737113L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr8", 0L, 147299246L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chr9", 0L, 142027288L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        new Contig("chrM", 0L, 1000001L)
+        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET)
+    };
+    
+    // These shards are "too big" to use in practice but for this test it keeps the
+    // expected result from getting crazy long.
+    assertThat(ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+        SexChromosomeFilter.EXCLUDE_XY, 150000000L, helper.auth),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+    
+    // Include sex chromosomes this time.
+    assertThat(ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+        SexChromosomeFilter.INCLUDE_XY, 150000000L, helper.auth),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT),
+            CoreMatchers.hasItems(EXPECTED_RESULT_XY)));
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsTest.java
@@ -1,0 +1,167 @@
+package com.google.cloud.genomics.utils;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import com.google.api.services.genomics.model.SearchReadsRequest;
+import com.google.api.services.genomics.model.SearchVariantsRequest;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamVariantsRequest;
+
+public class ShardUtilsTest {
+
+  @Test
+  public void testGetVariantRequestsStringStringLong() {
+    final StreamVariantsRequest[] EXPECTED_RESULT = {
+        new Contig("chr17", 41196311, 41246311)
+          .getStreamVariantsRequest("variantset1"),
+        new Contig("chr17", 41246311, 41277499)
+          .getStreamVariantsRequest("variantset1")
+    };
+    assertThat(ShardUtils.getVariantRequests("variantset1", "chr17:41196311:41277499", 50000L),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+  }
+
+  @Test
+  public void testGetPaginatedVariantRequestsStringStringLong() {
+    final SearchVariantsRequest[] EXPECTED_RESULT = {
+        new Contig("chr17", 41196311, 41246311)
+          .getSearchVariantsRequest("variantset1"),
+        new Contig("chr17", 41246311, 41277499)
+          .getSearchVariantsRequest("variantset1")
+    };
+    assertThat(ShardUtils.getPaginatedVariantRequests("variantset1", "chr17:41196311:41277499", 50000L),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+  }
+
+  @Test
+  public void testGetReadRequestsListOfStringStringLong() {
+    final StreamReadsRequest[] EXPECTED_RESULT = {
+        new Contig("chr17", 41196311, 41246311)
+          .getStreamReadsRequest("readset1"),
+        new Contig("chr17", 41246311, 41277499)
+          .getStreamReadsRequest("readset1"),
+          new Contig("chr17", 41196311, 41246311)
+        .getStreamReadsRequest("readset2"),
+      new Contig("chr17", 41246311, 41277499)
+        .getStreamReadsRequest("readset2")
+    };
+    assertThat(ShardUtils.getReadRequests(Arrays.asList("readset1", "readset2"), "chr17:41196311:41277499", 50000L),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+  }
+
+  @Test
+  public void testGetPaginatedReadRequests() {
+    final SearchReadsRequest[] EXPECTED_RESULT = {
+        new Contig("chr17", 41196311, 41246311)
+          .getSearchReadsRequest("readset1"),
+        new Contig("chr17", 41246311, 41277499)
+          .getSearchReadsRequest("readset1"),
+          new Contig("chr17", 41196311, 41246311)
+        .getSearchReadsRequest("readset2"),
+      new Contig("chr17", 41246311, 41277499)
+        .getSearchReadsRequest("readset2")
+    };
+    assertThat(ShardUtils.getPaginatedReadRequests(Arrays.asList("readset1", "readset2"), "chr17:41196311:41277499", 50000L),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+  }
+
+  @Test
+  public void testGetReadRequestsListOfString() {
+    final StreamReadsRequest[] EXPECTED_RESULT = {
+        StreamReadsRequest.newBuilder().setReadGroupSetId("readset1").build(),
+        StreamReadsRequest.newBuilder().setReadGroupSetId("readset2").build(),
+    };
+    assertThat(ShardUtils.getReadRequests(Arrays.asList("readset1", "readset2")),
+        CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+  }
+
+  @Test
+  public void testVariantShardsAreShuffled() throws Exception {
+    final StreamVariantsRequest[] EXPECTED_RESULT = {
+      new Contig("chr1", 0, 50)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr1", 50, 100)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr1", 100, 150)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr2", 25, 75)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr2", 75, 125)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr2", 125, 175)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr2", 175, 225)
+      .getStreamVariantsRequest("variantset1"),
+      new Contig("chr2", 225, 250)
+      .getStreamVariantsRequest("variantset1"),
+    };
+
+    List<StreamVariantsRequest> requests = ShardUtils.getVariantRequests("variantset1", "chr1:0:150,chr2:25:250", 50);
+    assertThat(requests, CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+    
+    // Call it a second time, expect the same set of shards but in a different order.
+    List<StreamVariantsRequest> requests2 = ShardUtils.getVariantRequests("variantset1", "chr1:0:150,chr2:25:250", 50);
+    assertThat(requests2, CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+
+    // Lists have different orders for their elements.
+    assertThat(requests, is(not(requests2)));
+  }
+
+  @Test
+  public void testReadShardsAreShuffled() throws Exception {
+    final StreamReadsRequest[] EXPECTED_RESULT = {
+      new Contig("chr1", 0, 50)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr1", 50, 100)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr1", 100, 150)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr2", 25, 75)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr2", 75, 125)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr2", 125, 175)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr2", 175, 225)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr2", 225, 250)
+      .getStreamReadsRequest("readset1"),
+      new Contig("chr1", 0, 50)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr1", 50, 100)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr1", 100, 150)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr2", 25, 75)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr2", 75, 125)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr2", 125, 175)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr2", 175, 225)
+      .getStreamReadsRequest("readset2"),
+      new Contig("chr2", 225, 250)
+      .getStreamReadsRequest("readset2"),
+    };
+
+    List<StreamReadsRequest> requests = ShardUtils.getReadRequests(Arrays.asList("readset1", "readset2"),
+        "chr1:0:150,chr2:25:250", 50);
+    assertThat(requests, CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+    
+    // Call it a second time, expect the same set of shards but in a different order.
+    List<StreamReadsRequest> requests2 = ShardUtils.getReadRequests(Arrays.asList("readset1", "readset2"),
+        "chr1:0:150,chr2:25:250", 50);
+    assertThat(requests2, CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
+
+    // Lists have different orders for their elements.
+    assertThat(requests, is(not(requests2)));
+  }
+}


### PR DESCRIPTION
Logic to shard genomic ranges should be all in one place to be reused by both dataflow and spark.  Its also important to ensure that the full collection of shards is shuffled so that parallel requests will be distributed across the dataset.

This pull request is part 1 of many parts to refactor some logic currently in dataflow-java down into utils-java so that it can be more widely re-used.  Since this code may change yet again, sending these pull requests to a branch for now instead of master.