### PR TITLE
Refactor streamers from dataflow-java for reuse by spark.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,24 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java7profile</id>
+        <activation>
+          <jdk>[1.7, 1.8)</jdk>
+        </activation>
+      <properties>
+        <alpn.jar>${basedir}/lib/alpn-boot-7.1.3.v20150130.jar</alpn.jar>
+      </properties>
+    </profile>
+    <profile>
+      <id>java8profile</id>
+        <activation>
+          <jdk>[1.8, 1.9)</jdk>
+        </activation>
+      <properties>
+        <alpn.jar>${basedir}/lib/alpn-boot-8.1.3.v20150130.jar</alpn.jar>
+      </properties>
+    </profile>
   </profiles>
 
   <build>
@@ -180,6 +198,7 @@
         <version>2.18.1</version>
         <configuration>
           <useSystemClassLoader>false</useSystemClassLoader>
+          <argLine>-Xbootclasspath/p:${alpn.jar}</argLine>
         </configuration>
         <executions>
           <execution>

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
@@ -15,6 +15,18 @@
  */
 package com.google.cloud.genomics.utils;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.security.GeneralSecurityException;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.annotation.Nullable;
+
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
 import com.google.api.client.extensions.java6.auth.oauth2.VerificationCodeReceiver;
@@ -40,24 +52,14 @@ import com.google.api.client.util.store.DataStoreFactory;
 import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.genomics.Genomics;
 import com.google.api.services.genomics.GenomicsScopes;
+import com.google.auth.oauth2.UserCredentials;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.io.Files;
-
-import javax.annotation.Nullable;
-
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
-import java.io.Serializable;
-import java.io.StringReader;
-import java.security.GeneralSecurityException;
-import java.util.Collection;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Code required to manufacture instances of a {@link Genomics} stub. Right now, there are 3
@@ -674,6 +676,18 @@ public class GenomicsFactory {
           .build()
           .setAccessToken(accessToken)
           .setRefreshToken(refreshToken), new CommonGoogleClientRequestInitializer(apiKey));
+    }
+  
+    public UserCredentials getUserCredentials() throws IOException, GeneralSecurityException {
+      Preconditions.checkNotNull(clientSecretsString,
+          "Authorization needed.  (An API key is not sufficient for this usage.)");
+      Preconditions.checkNotNull(refreshToken,
+          "Authorization needed.  (An API key is not sufficient for this usage.)");
+      GoogleClientSecrets secrets = GoogleClientSecrets.load(getDefaultFactory().jsonFactory,
+          new StringReader(clientSecretsString));
+      UserCredentials creds = new UserCredentials(secrets.getDetails().getClientId(),
+          secrets.getDetails().getClientSecret(), refreshToken);
+      return creds;
     }
   }
 }

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
@@ -1,0 +1,55 @@
+package com.google.cloud.genomics.utils.grpc;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Iterator;
+
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.common.collect.ForwardingIterator;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamReadsResponse;
+import com.google.genomics.v1.StreamingReadServiceGrpc;
+
+/**
+ *  Class with tools for streaming reads via gRPC.
+ * 
+ * TODO:
+ * - facilitate shard boundary requirement https://github.com/googlegenomics/utils-java/issues/30
+ * - facilitate partial requests https://github.com/googlegenomics/utils-java/issues/48
+ */
+public class ReadStreamIterator extends ForwardingIterator<StreamReadsResponse> {
+
+  private Iterator<StreamReadsResponse> delegate;
+
+  /**
+   * @param request
+   * @param auth
+   * @throws IOException
+   * @throws GeneralSecurityException
+   */
+  public ReadStreamIterator(StreamReadsRequest request, GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+    // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
+    // partial request.
+
+    // TODO: When gRPC is no longer behind a whitelist, support api keys too. 
+    StreamingReadServiceGrpc.StreamingReadServiceBlockingStub readStub =
+        StreamingReadServiceGrpc.newBlockingStub(Channels.fromCreds(auth.getUserCredentials()));
+    
+    delegate = readStub.streamReads(request);
+  }
+  
+  @Override
+  protected Iterator<StreamReadsResponse> delegate() {
+    return delegate;
+  }
+
+  /**
+   * @see java.util.Iterator#next()
+   */
+  public StreamReadsResponse next() {
+    // TODO: Facilitate shard boundary predicate here by skipping any reads that overlap the
+    // start position.
+    return delegate.next();
+  }
+  
+}

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
@@ -1,0 +1,55 @@
+package com.google.cloud.genomics.utils.grpc;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Iterator;
+
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.common.collect.ForwardingIterator;
+import com.google.genomics.v1.StreamVariantsRequest;
+import com.google.genomics.v1.StreamVariantsResponse;
+import com.google.genomics.v1.StreamingVariantServiceGrpc;
+
+/**
+ *  Class with tools for streaming variants via gRPC.
+ * 
+ * TODO:
+ * - facilitate shard boundary requirement https://github.com/googlegenomics/utils-java/issues/30
+ * - facilitate partial requests https://github.com/googlegenomics/utils-java/issues/48
+ */
+public class VariantStreamIterator extends ForwardingIterator<StreamVariantsResponse> {
+
+  private Iterator<StreamVariantsResponse> delegate;
+
+  /**
+   * @param request
+   * @param auth
+   * @throws IOException
+   * @throws GeneralSecurityException
+   */
+  public VariantStreamIterator(StreamVariantsRequest request, GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+    // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
+    // partial request.
+
+    // TODO: When gRPC is no longer behind a whitelist, support api keys too. 
+    StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub variantStub =
+        StreamingVariantServiceGrpc.newBlockingStub(Channels.fromCreds(auth.getUserCredentials()));
+    
+    delegate = variantStub.streamVariants(request);
+  }
+  
+  @Override
+  protected Iterator<StreamVariantsResponse> delegate() {
+    return delegate;
+  }
+
+  /**
+   * @see java.util.Iterator#next()
+   */
+  public StreamVariantsResponse next() {
+    // TODO: Facilitate shard boundary predicate here by skipping any variants that overlap the
+    // start position.
+    return delegate.next();
+  }
+  
+}

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryITCase.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.testing.http.HttpTesting;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.api.services.genomics.Genomics;
+import com.google.api.services.genomics.GenomicsScopes;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.common.collect.Lists;
+
+@RunWith(JUnit4.class)
+public class GenomicsFactoryITCase {
+
+  @Test
+  public void testBackendErrorRetries() throws Exception {
+
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+            response.setStatusCode(500);
+            return response;
+          }
+        };
+      }
+    };
+
+    GenomicsFactory genomicsFactory =
+        GenomicsFactory.builder("test_client").setHttpTransport(transport).build();
+    Genomics genomics = genomicsFactory.fromApiKey("xyz");
+
+    HttpRequest request =
+        genomics.getRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    try {
+      request.execute();
+      fail("this request should not have succeeded");
+    } catch (HttpResponseException e) {
+    }
+
+    assertEquals(1, genomicsFactory.initializedRequestsCount());
+    assertEquals(6, genomicsFactory.unsuccessfulResponsesCount());
+    assertEquals(0, genomicsFactory.ioExceptionsCount());
+  }
+
+  @Test
+  public void testIOExceptionRetries() throws Exception {
+
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            throw new IOException();
+          }
+        };
+      }
+    };
+
+    GenomicsFactory genomicsFactory =
+        GenomicsFactory.builder("test_client").setHttpTransport(transport).build();
+    Genomics genomics = genomicsFactory.fromApiKey("xyz");
+
+    HttpRequest request =
+        genomics.getRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    try {
+      request.execute();
+      fail("this request should not have succeeded");
+    } catch (IOException e) {
+    }
+
+    assertEquals(1, genomicsFactory.initializedRequestsCount());
+    assertEquals(0, genomicsFactory.unsuccessfulResponsesCount());
+    assertEquals(6, genomicsFactory.ioExceptionsCount());
+  }
+
+  @Test
+  public void testUserErrorRetries() throws Exception {
+
+    HttpTransport transport = new MockHttpTransport() {
+      @Override
+      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+        return new MockLowLevelHttpRequest() {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+            response.setStatusCode(404);
+            return response;
+          }
+        };
+      }
+    };
+
+    GenomicsFactory genomicsFactory =
+        GenomicsFactory.builder("test_client").setHttpTransport(transport).build();
+    Genomics genomics = genomicsFactory.fromApiKey("xyz");
+
+    HttpRequest request =
+        genomics.getRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+    try {
+      request.execute();
+      fail("this request should not have succeeded");
+    } catch (HttpResponseException e) {
+    }
+
+    assertEquals(1, genomicsFactory.initializedRequestsCount());
+    assertEquals(1, genomicsFactory.unsuccessfulResponsesCount());
+    assertEquals(0, genomicsFactory.ioExceptionsCount());
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryTest.java
@@ -186,103 +186,16 @@ public class GenomicsFactoryTest {
   }
 
   @Test
-  public void testBackendErrorRetries() throws Exception {
-
-    HttpTransport transport = new MockHttpTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-        return new MockLowLevelHttpRequest() {
-          @Override
-          public LowLevelHttpResponse execute() throws IOException {
-            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-            response.setStatusCode(500);
-            return response;
-          }
-        };
-      }
-    };
-
-    GenomicsFactory genomicsFactory =
-        GenomicsFactory.builder("test_client").setHttpTransport(transport).build();
-    Genomics genomics = genomicsFactory.fromApiKey("xyz");
-
-    HttpRequest request =
-        genomics.getRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
+  public void testOfflineAuthGetUserCredential() throws Exception {
+    GenomicsFactory genomicsFactory = GenomicsFactory.builder("test_client").build();
+    GenomicsFactory.OfflineAuth auth = genomicsFactory.getOfflineAuthFromApiKey("xyz");
     try {
-      request.execute();
-      fail("this request should not have succeeded");
-    } catch (HttpResponseException e) {
+      auth.getUserCredentials();
+      fail("getUserCredentials did not throw expected exception");
+    } catch(NullPointerException e) {
+      // The exception message shoud say something about the API key at a minimum.
+      assertTrue(e.getMessage().contains("API key"));
     }
-
-    assertEquals(1, genomicsFactory.initializedRequestsCount());
-    assertEquals(6, genomicsFactory.unsuccessfulResponsesCount());
-    assertEquals(0, genomicsFactory.ioExceptionsCount());
-  }
-
-  @Test
-  public void testIOExceptionRetries() throws Exception {
-
-    HttpTransport transport = new MockHttpTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-        return new MockLowLevelHttpRequest() {
-          @Override
-          public LowLevelHttpResponse execute() throws IOException {
-            throw new IOException();
-          }
-        };
-      }
-    };
-
-    GenomicsFactory genomicsFactory =
-        GenomicsFactory.builder("test_client").setHttpTransport(transport).build();
-    Genomics genomics = genomicsFactory.fromApiKey("xyz");
-
-    HttpRequest request =
-        genomics.getRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
-    try {
-      request.execute();
-      fail("this request should not have succeeded");
-    } catch (IOException e) {
-    }
-
-    assertEquals(1, genomicsFactory.initializedRequestsCount());
-    assertEquals(0, genomicsFactory.unsuccessfulResponsesCount());
-    assertEquals(6, genomicsFactory.ioExceptionsCount());
-  }
-
-  @Test
-  public void testUserErrorRetries() throws Exception {
-
-    HttpTransport transport = new MockHttpTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-        return new MockLowLevelHttpRequest() {
-          @Override
-          public LowLevelHttpResponse execute() throws IOException {
-            MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-            response.setStatusCode(404);
-            return response;
-          }
-        };
-      }
-    };
-
-    GenomicsFactory genomicsFactory =
-        GenomicsFactory.builder("test_client").setHttpTransport(transport).build();
-    Genomics genomics = genomicsFactory.fromApiKey("xyz");
-
-    HttpRequest request =
-        genomics.getRequestFactory().buildGetRequest(HttpTesting.SIMPLE_GENERIC_URL);
-    try {
-      request.execute();
-      fail("this request should not have succeeded");
-    } catch (HttpResponseException e) {
-    }
-
-    assertEquals(1, genomicsFactory.initializedRequestsCount());
-    assertEquals(1, genomicsFactory.unsuccessfulResponsesCount());
-    assertEquals(0, genomicsFactory.ioExceptionsCount());
   }
   
 }

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
@@ -35,25 +35,25 @@ public class GenomicsUtilsITCase {
   
   @Test
   public void testGetReadGroupSetIds() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getReadGroupSetIds(helper.PLATINUM_GENOMES_DATASET, helper.auth),
+    assertThat(GenomicsUtils.getReadGroupSetIds(helper.PLATINUM_GENOMES_DATASET, helper.getAuth()),
         CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_READGROUPSETS))); 
   }
 
   @Test
   public void testGetVariantSetIds() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getVariantSetIds(helper.PLATINUM_GENOMES_DATASET, helper.auth),
+    assertThat(GenomicsUtils.getVariantSetIds(helper.PLATINUM_GENOMES_DATASET, helper.getAuth()),
         CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_VARIANTSET))); 
   }
 
   @Test
   public void testGetCallSetsNames() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getCallSetsNames(helper.PLATINUM_GENOMES_VARIANTSET, helper.auth),
+    assertThat(GenomicsUtils.getCallSetsNames(helper.PLATINUM_GENOMES_VARIANTSET, helper.getAuth()),
         CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_CALLSET_NAMES))); 
   }
 
   @Test
   public void testGetReferenceBounds() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getReferenceBounds(helper.PLATINUM_GENOMES_VARIANTSET, helper.auth),
+    assertThat(GenomicsUtils.getReferenceBounds(helper.PLATINUM_GENOMES_VARIANTSET, helper.getAuth()),
         CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_VARIANTSET_BOUNDS))); 
   }
 

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -15,12 +15,13 @@
  */
 package com.google.cloud.genomics.utils;
 
+import static org.junit.Assert.assertNotNull;
+
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-import org.junit.Assert;
-
 import com.google.api.services.genomics.model.ReferenceBound;
+import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
 import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
 
 /**
@@ -69,6 +70,7 @@ public class IntegrationTestHelper {
     "CMvnhpKTFhCrvIOEw4Ol__sB",
   };
   public static final String PLATINUM_GENOMES_BRCA1_REFERENCES = "chr17:41196311:41277499";
+  public static final String PLATINUM_GENOMES_KLOTHO_REFERENCES = "chr13:33628137:33628138";
   public static final ReferenceBound[] PLATINUM_GENOMES_VARIANTSET_BOUNDS = {
     new ReferenceBound().setReferenceName("chr1").setUpperBound(250226910L),
     new ReferenceBound().setReferenceName("chr10").setUpperBound(136466007L),
@@ -97,12 +99,37 @@ public class IntegrationTestHelper {
     new ReferenceBound().setReferenceName("chrY").setUpperBound(60032946L)
   };
 
-  // Test configuration constants
-  public final String API_KEY = System.getenv("GOOGLE_API_KEY");
-  public final OfflineAuth auth;
+  private final String API_KEY = System.getenv("GOOGLE_API_KEY");
+  private final OfflineAuth auth;
   
   public IntegrationTestHelper() throws IOException, GeneralSecurityException {
-    Assert.assertNotNull("You must set the GOOGLE_API_KEY environment variable for this test.", API_KEY);
+    assertNotNull("You must set the GOOGLE_API_KEY environment variable for this test.", API_KEY);
      auth = GenomicsFactory.builder("integration test").build().getOfflineAuthFromApiKey(API_KEY);
+  }
+
+  /**
+   * @return the API_KEY
+   */
+  public String getAPI_KEY() {
+    return API_KEY;
+  }
+
+  /**
+   * @return the auth
+   */
+  public OfflineAuth getAuth() {
+    return auth;
+  }
+  
+  // TODO: Remove this whole method when gRPC is no longer behind a whitelist.  We really want to keep 
+  // integration tests to just API_KEY to keep them simple and only functional against public data.
+  public GenomicsFactory.OfflineAuth getAuthWithUserCredentials() throws GeneralSecurityException, IOException {
+    // This code is intentionally all in one method to make it easier to remove.
+    final String ENV_VAR = "GOOGLE_CLIENT_SECRETS_FILEPATH";
+    final String CLIENT_SECRECTS_FILEPATH = System.getenv(ENV_VAR);
+    assertNotNull("You must set the " + ENV_VAR + " environment variable for this test.", CLIENT_SECRECTS_FILEPATH);
+    
+    Builder builder = GenomicsFactory.builder(IntegrationTestHelper.class.getName());
+    return builder.build().getOfflineAuthFromClientSecretsFile(CLIENT_SECRECTS_FILEPATH);
   }
 }

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
@@ -99,12 +99,12 @@ public class ShardUtilsITCase {
     // These shards are "too big" to use in practice but for this test it keeps the
     // expected result from getting crazy long.
     assertThat(ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-        SexChromosomeFilter.EXCLUDE_XY, 150000000L, helper.auth),
+        SexChromosomeFilter.EXCLUDE_XY, 150000000L, helper.getAuth()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
     
     // Include sex chromosomes this time.
     assertThat(ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-        SexChromosomeFilter.INCLUDE_XY, 150000000L, helper.auth),
+        SexChromosomeFilter.INCLUDE_XY, 150000000L, helper.getAuth()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT),
             CoreMatchers.hasItems(EXPECTED_RESULT_XY)));
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -1,0 +1,40 @@
+package com.google.cloud.genomics.utils.grpc;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.cloud.genomics.utils.IntegrationTestHelper;
+import com.google.cloud.genomics.utils.ShardUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamReadsResponse;
+
+public class ReadStreamIteratorITCase {
+
+  static IntegrationTestHelper helper;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    helper = new IntegrationTestHelper();
+  }
+  
+  @Test
+  public void testBasic() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamReadsRequest> requests = ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+    assertEquals(1, requests.size());
+    Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0), helper.getAuthWithUserCredentials());
+    assertTrue(iter.hasNext());
+    StreamReadsResponse readResponse = iter.next();
+    assertEquals(55, readResponse.getAlignmentsList().size());
+    assertFalse(iter.hasNext());
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -1,0 +1,39 @@
+package com.google.cloud.genomics.utils.grpc;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Iterator;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.cloud.genomics.utils.IntegrationTestHelper;
+import com.google.cloud.genomics.utils.ShardUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.genomics.v1.StreamVariantsRequest;
+import com.google.genomics.v1.StreamVariantsResponse;
+
+public class VariantStreamIteratorITCase {
+
+  static IntegrationTestHelper helper;
+  
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    helper = new IntegrationTestHelper();
+  }
+  
+  @Test
+  public void testBasic() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+        helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+    assertEquals(1, requests.size());
+    Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0), helper.getAuthWithUserCredentials());
+    assertTrue(iter.hasNext());
+    StreamVariantsResponse variantResponse = iter.next();
+    assertEquals(4, variantResponse.getVariantsList().size());
+    assertFalse(iter.hasNext());
+  }
+
+}


### PR DESCRIPTION
Also updated auth in the streamers to use user credentials.

Fixes 
* https://github.com/googlegenomics/utils-java/issues/34
* https://github.com/googlegenomics/utils-java/issues/35
* https://github.com/googlegenomics/dataflow-java/issues/122

I also moved a few GenomicsFactory unit tests that check retries into an ITCase file since they incur some time to run.