### PR TITLE
Work around auth + whitelist issues.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
@@ -678,16 +678,37 @@ public class GenomicsFactory {
           .setRefreshToken(refreshToken), new CommonGoogleClientRequestInitializer(apiKey));
     }
   
+    /**
+     * Convert the information in an OfflineAuth instance to a UserCredentials object.
+     * 
+     * Specifically, gRPC uses the new Google OAuth library.  See https://github.com/google/google-auth-library-java
+     * 
+     * @return The UserCredentials object.
+     * @throws IOException
+     * @throws GeneralSecurityException
+     */
     public UserCredentials getUserCredentials() throws IOException, GeneralSecurityException {
-      Preconditions.checkNotNull(clientSecretsString,
-          "Authorization needed.  (An API key is not sufficient for this usage.)");
-      Preconditions.checkNotNull(refreshToken,
+      Preconditions.checkState(hasUserCredentials(),
           "Authorization needed.  (An API key is not sufficient for this usage.)");
       GoogleClientSecrets secrets = GoogleClientSecrets.load(getDefaultFactory().jsonFactory,
           new StringReader(clientSecretsString));
       UserCredentials creds = new UserCredentials(secrets.getDetails().getClientId(),
           secrets.getDetails().getClientSecret(), refreshToken);
       return creds;
+    }
+    
+    /**
+     * @return Whether a UserCredentials object can be constructed from the information in this OfflineAuth.
+     */
+    public boolean hasUserCredentials() {
+      return null != clientSecretsString && null != refreshToken;
+    }
+    
+    /**
+     * @return Whether an api key is in this OfflineAuth.
+     */
+    public boolean hasApiKey() {
+      return null != apiKey;
     }
   }
 }

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/Channels.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/Channels.java
@@ -1,23 +1,33 @@
 package com.google.cloud.genomics.utils.grpc;
 
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+
 import io.grpc.Channel;
 import io.grpc.ClientInterceptors;
+import io.grpc.Metadata;
 import io.grpc.auth.ClientAuthInterceptor;
+import io.grpc.stub.MetadataUtils;
 import io.grpc.transport.netty.GrpcSslContexts;
 import io.grpc.transport.netty.NegotiationType;
 import io.grpc.transport.netty.NettyChannelBuilder;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 
+import javax.net.ssl.SSLException;
+
 /**
  * A convenience class for creating gRPC channels to the Google Genomics API.
  */
 public class Channels {
+  // TODO: This constant should come from grpc-java.
+  private static final String API_KEY_HEADER = "X-Goog-Api-Key";
+
   /**
    * Creates a new gRPC channel to the Google Genomics API, using the application
    * default credentials for auth.
@@ -28,9 +38,53 @@ public class Channels {
   
   /**
    * Creates a new gRPC channel to the Google Genomics API, using the provided
+   * api key for auth.
+   */
+  public static Channel fromApiKey(String apiKey) throws SSLException {
+    Metadata.Headers headers = new Metadata.Headers();
+    Metadata.Key<String> apiKeyHeaderKey =
+        Metadata.Key.of(API_KEY_HEADER, Metadata.ASCII_STRING_MARSHALLER);
+    headers.put(apiKeyHeaderKey, apiKey);
+    return ClientInterceptors.intercept(getGenomicsChannel(),
+        MetadataUtils.newAttachHeadersInterceptor(headers));
+  }
+  
+  /**
+   * Creates a new gRPC channel to the Google Genomics API, using the provided
    * credentials for auth.
    */
   public static Channel fromCreds(GoogleCredentials creds) throws IOException {
+    creds = creds.createScoped(
+        Arrays.asList("https://www.googleapis.com/auth/genomics"));
+    ClientAuthInterceptor interceptor = new ClientAuthInterceptor(creds,
+        Executors.newSingleThreadExecutor());
+    return ClientInterceptors.intercept(getGenomicsChannel(), interceptor);     
+  }
+  
+  /**
+   * Initialize auth for a gRPC channel from OfflineAuth or the application default credentials.
+   * 
+   * This library works with both the older and newer support for OAuth2 clients.
+   * 
+   * https://developers.google.com/identity/protocols/application-default-credentials
+   * 
+   * @param auth An OfflineAuth object.
+   * @return The gRPC channel authorized using either the information in the OfflineAuth or application default credentials.
+   * @throws IOException
+   * @throws GeneralSecurityException
+   */
+  public static Channel fromOfflineAuth(GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+    if(auth.hasUserCredentials()) {
+      return fromCreds(auth.getUserCredentials());
+// TODO: https://github.com/googlegenomics/utils-java/issues/51      
+//    } else if(auth.hasApiKey()) {
+//      return fromApiKey(auth.apiKey);
+    }
+    // Fall back to Default Credentials if the user did not specify user credentials or an api key.
+    return fromDefaultCreds();
+  }
+  
+  private static Channel getGenomicsChannel() throws SSLException {
     // Java 8's implementation of GCM ciphers is extremely slow. Therefore we disable
     // them here.
     List<String> defaultCiphers =
@@ -47,11 +101,7 @@ public class Channels {
         .streamWindowSize(1000000)
         .sslContext(GrpcSslContexts.forClient().ciphers(performantCiphers).build())
         .build();
-    creds = creds.createScoped(
-        Arrays.asList("https://www.googleapis.com/auth/genomics"));
-    ClientAuthInterceptor interceptor = new ClientAuthInterceptor(creds,
-        Executors.newSingleThreadExecutor());
-    return ClientInterceptors.intercept(channel, interceptor);     
+    return channel;
   }
 }
 

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
@@ -31,9 +31,8 @@ public class ReadStreamIterator extends ForwardingIterator<StreamReadsResponse> 
     // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
     // partial request.
 
-    // TODO: When gRPC is no longer behind a whitelist, support api keys too. 
     StreamingReadServiceGrpc.StreamingReadServiceBlockingStub readStub =
-        StreamingReadServiceGrpc.newBlockingStub(Channels.fromCreds(auth.getUserCredentials()));
+        StreamingReadServiceGrpc.newBlockingStub(Channels.fromOfflineAuth(auth));
     
     delegate = readStub.streamReads(request);
   }

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
@@ -30,10 +30,9 @@ public class VariantStreamIterator extends ForwardingIterator<StreamVariantsResp
   public VariantStreamIterator(StreamVariantsRequest request, GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
     // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
     // partial request.
-
-    // TODO: When gRPC is no longer behind a whitelist, support api keys too. 
+    
     StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub variantStub =
-        StreamingVariantServiceGrpc.newBlockingStub(Channels.fromCreds(auth.getUserCredentials()));
+        StreamingVariantServiceGrpc.newBlockingStub(Channels.fromOfflineAuth(auth));
     
     delegate = variantStub.streamVariants(request);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryTest.java
@@ -192,7 +192,7 @@ public class GenomicsFactoryTest {
     try {
       auth.getUserCredentials();
       fail("getUserCredentials did not throw expected exception");
-    } catch(NullPointerException e) {
+    } catch(IllegalStateException e) {
       // The exception message shoud say something about the API key at a minimum.
       assertTrue(e.getMessage().contains("API key"));
     }

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -123,6 +123,7 @@ public class IntegrationTestHelper {
   
   // TODO: Remove this whole method when gRPC is no longer behind a whitelist.  We really want to keep 
   // integration tests to just API_KEY to keep them simple and only functional against public data.
+  // https://github.com/googlegenomics/utils-java/issues/51
   public GenomicsFactory.OfflineAuth getAuthWithUserCredentials() throws GeneralSecurityException, IOException {
     // This code is intentionally all in one method to make it easier to remove.
     final String ENV_VAR = "GOOGLE_CLIENT_SECRETS_FILEPATH";

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -27,10 +27,19 @@ public class ReadStreamIteratorITCase {
   
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
-    ImmutableList<StreamReadsRequest> requests = ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+    ImmutableList<StreamReadsRequest> requests =
+        ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
         helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
-    Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0), helper.getAuthWithUserCredentials());
+    
+    // TODO: switch this to helper.getAuth() to use api key once gRPC is no longer behind a whitelist.
+    // At that time, application default credentials would also work.  Right now application default credentials
+    // will not work locally since they come from a gcloud project not in the whitelist.  Application default
+    // credentials do work fine on Google Compute Engine if running in a project in the whitelist.
+    // https://github.com/googlegenomics/utils-java/issues/51
+    Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0),
+        helper.getAuthWithUserCredentials());
+    
     assertTrue(iter.hasNext());
     StreamReadsResponse readResponse = iter.next();
     assertEquals(55, readResponse.getAlignmentsList().size());

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -26,10 +26,19 @@ public class VariantStreamIteratorITCase {
   
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
-    ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
         helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
-    Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0), helper.getAuthWithUserCredentials());
+
+    // TODO: switch this to helper.getAuth() to use api key once gRPC is no longer behind a whitelist.
+    // At that time, application default credentials would also work.  Right now application default credentials
+    // will not work locally since they come from a gcloud project not in the whitelist.  Application default
+    // credentials do work fine on Google Compute Engine if running in a project in the whitelist.
+    // https://github.com/googlegenomics/utils-java/issues/51
+    Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0),
+        helper.getAuthWithUserCredentials());
+
     assertTrue(iter.hasNext());
     StreamVariantsResponse variantResponse = iter.next();
     assertEquals(4, variantResponse.getVariantsList().size());


### PR DESCRIPTION
This fixes `mvn verify` for https://github.com/googlegenomics/dataflow-java/pull/124

We're in a middle place with auth and gRPC right now.  Regarding integration tests for gRPC:
 * the ones in utils-java use a user credential which is currently the only way to auth for local runs.
 * the ones in dataflow-java use the application default credential and run on Google Compute Engine.

My point is that we do have good integration test coverage, even though we have some constraints regarding the whitelist and api key support in gRPC for now.