### PR TITLE
Enforce shard boundaries for gRPC.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils;
 
 import java.io.IOException;

--- a/src/main/java/com/google/cloud/genomics/utils/Paginator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Paginator.java
@@ -108,8 +108,6 @@ import com.google.common.collect.Maps;
  */
 public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
   
-  public enum ShardBoundary { OVERLAPS, STRICT }
-
   /**
    * A callback object for
    * {@link #search(Object, GenomicsRequestInitializer, Callback, RetryPolicy)} that can
@@ -331,7 +329,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
         .put("alignment", ".*\\p{Punct}alignment\\p{Punct}.*") 
         .put("position", ".*\\p{Punct}position\\p{Punct}.*")
         .build();
-    private final ShardBoundary shardBoundary;
+    private final ShardBoundary.Requirement shardBoundary;
     private Predicate<Read> shardPredicate = null;
 
     /**
@@ -348,11 +346,11 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
      *        ShardBoundary.STRICT to ensure that a record does not appear in more than one shard.
      * @return the new paginator.
      */
-    public static Reads create(Genomics genomics, ShardBoundary shardBoundary) {
+    public static Reads create(Genomics genomics, ShardBoundary.Requirement shardBoundary) {
       return new Reads(genomics, shardBoundary);
     }
 
-    private Reads(Genomics genomics, ShardBoundary shardBoundary) {
+    private Reads(Genomics genomics, ShardBoundary.Requirement shardBoundary) {
       super(genomics);
       this.shardBoundary = shardBoundary;
     }
@@ -360,7 +358,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
     @Override Genomics.Reads.Search createSearch(Genomics.Reads api, final SearchReadsRequest request,
         Optional<String> pageToken) throws IOException {
 
-      if(shardBoundary == ShardBoundary.STRICT) {
+      if(shardBoundary == ShardBoundary.Requirement.STRICT) {
         // TODO: When this is supported server-side, instead verify that request.getIntersectionType
         // will yield a strict shard.
         shardPredicate = new Predicate<Read>() {
@@ -383,7 +381,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
 
     @Override
     public GenomicsRequestInitializer<GenomicsRequest<?>> setFieldsInitializer(final String fields) {
-      if(shardBoundary == ShardBoundary.STRICT) {
+      if(shardBoundary == ShardBoundary.Requirement.STRICT) {
         return new GenomicsSearchFieldRequestInitializer(fields, REQUIRED_STRICT_SHARD_FIELDS);        
       }
       return new GenomicsSearchFieldRequestInitializer(fields, REQUIRED_FIELDS);
@@ -423,7 +421,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
         .put("position", ".*\\p{Punct}position\\p{Punct}.*")
         .put("start", ".*\\p{Punct}start\\p{Punct}.*") 
         .build();
-    private final ShardBoundary shardBoundary;
+    private final ShardBoundary.Requirement shardBoundary;
     private Predicate<Annotation> shardPredicate = null;
 
     /**
@@ -440,11 +438,11 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
      *        ShardBoundary.STRICT to ensure that a record does not appear in more than one shard.
      * @return the new paginator.
      */
-    public static Annotations create(Genomics genomics, ShardBoundary shardBoundary) {
+    public static Annotations create(Genomics genomics, ShardBoundary.Requirement shardBoundary) {
       return new Annotations(genomics, shardBoundary);
     }
 
-    private Annotations(Genomics genomics, ShardBoundary shardBoundary) {
+    private Annotations(Genomics genomics, ShardBoundary.Requirement shardBoundary) {
       super(genomics);
       this.shardBoundary = shardBoundary;
     }
@@ -452,7 +450,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
     @Override Genomics.Annotations.Search createSearch(Genomics.Annotations api,
         final SearchAnnotationsRequest request, Optional<String> pageToken) throws IOException {
 
-      if(shardBoundary == ShardBoundary.STRICT) {
+      if(shardBoundary == ShardBoundary.Requirement.STRICT) {
         // TODO: When this is supported server-side, instead verify that request.getIntersectionType
         // will yield a strict shard.
         shardPredicate = new Predicate<Annotation>() {
@@ -474,7 +472,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
 
     @Override
     public GenomicsRequestInitializer<GenomicsRequest<?>> setFieldsInitializer(final String fields) {
-      if(shardBoundary == ShardBoundary.STRICT) {
+      if(shardBoundary == ShardBoundary.Requirement.STRICT) {
         return new GenomicsSearchFieldRequestInitializer(fields, REQUIRED_STRICT_SHARD_FIELDS);        
       }
       return new GenomicsSearchFieldRequestInitializer(fields, REQUIRED_FIELDS);
@@ -825,7 +823,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
         .putAll(REQUIRED_FIELDS)
         .put("start", ".*\\p{Punct}start\\p{Punct}.*") 
         .build();
-    private final ShardBoundary shardBoundary;
+    private final ShardBoundary.Requirement shardBoundary;
     private Predicate<Variant> shardPredicate = null;
     
     /**
@@ -842,11 +840,11 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
      *        ShardBoundary.STRICT to ensure that a record does not appear in more than one shard.
      * @return the new paginator
      */
-    public static Variants create(Genomics genomics, ShardBoundary shardBoundary) {
+    public static Variants create(Genomics genomics, ShardBoundary.Requirement shardBoundary) {
       return new Variants(genomics, shardBoundary);
     }
 
-    private Variants(Genomics genomics, ShardBoundary shardBoundary) {
+    private Variants(Genomics genomics, ShardBoundary.Requirement shardBoundary) {
       super(genomics);
       this.shardBoundary = shardBoundary;
     }
@@ -854,7 +852,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
     @Override Genomics.Variants.Search createSearch(Genomics.Variants api,
         final SearchVariantsRequest request, Optional<String> pageToken) throws IOException {
       
-      if(shardBoundary == ShardBoundary.STRICT) {
+      if(shardBoundary == ShardBoundary.Requirement.STRICT) {
         // TODO: When this is supported server-side, instead verify that request.getIntersectionType
         // will yield a strict shard.
         shardPredicate = new Predicate<Variant>() {
@@ -877,7 +875,7 @@ public abstract class Paginator<A, B, C extends GenomicsRequest<D>, D, E> {
 
     @Override
     public GenomicsRequestInitializer<GenomicsRequest<?>> setFieldsInitializer(final String fields) {
-      if(shardBoundary == ShardBoundary.STRICT) {
+      if(shardBoundary == ShardBoundary.Requirement.STRICT) {
         return new GenomicsSearchFieldRequestInitializer(fields, REQUIRED_STRICT_SHARD_FIELDS);        
       }
       return new GenomicsSearchFieldRequestInitializer(fields, REQUIRED_FIELDS);

--- a/src/main/java/com/google/cloud/genomics/utils/ShardBoundary.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ShardBoundary.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import com.google.common.base.Predicate;
+import com.google.genomics.v1.Read;
+import com.google.genomics.v1.Variant;
+
+/**
+ * By default cluster compute jobs working with sharded data from the Genomics API will
+ * see any records that span a shard boundary in both shards. In some cases this is
+ * desired; in others it is not.  It just depends upon the particular analysis.
+ */
+public class ShardBoundary {
+
+  /**
+   * Enum for shard boundary requirement.
+   */
+  public enum Requirement {
+   /**
+   * Use OVERLAPS if data overlapping the start of the shard should be returned.
+   */
+  OVERLAPS,
+  /**
+   * Use STRICT if data overlapping the start of the shard should be excluded.
+   */
+  STRICT }
+ 
+  /**
+   * Predicate expressing the logic for which variants should and should not be included in the shard.
+   * 
+   * @param start The start position of the shard.
+   * @return Whether the variant would be included in a strict shard boundary.
+   */
+  public static Predicate<Variant> getStrictVariantPredicate(final long start) {
+    return new Predicate<Variant>() {
+      @Override
+      public boolean apply(Variant variant) {
+        return variant.getStart() >= start;
+      }
+    };
+  }
+
+  /**
+   * Predicate expressing the logic for which reads should and should not be included in the shard.
+   * 
+   * @param start The start position of the shard.
+   * @return Whether the read would be included in a strict shard boundary.
+   */
+  public static Predicate<Read> getStrictReadPredicate(final long start) {
+    return new Predicate<Read>() {
+      @Override
+      public boolean apply(Read read) {
+        return read.getAlignment().getPosition().getPosition() >= start;
+      }
+    };
+  }
+
+}

--- a/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils;
 
 import java.io.IOException;

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/Example.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/Example.java
@@ -1,14 +1,12 @@
 package com.google.cloud.genomics.utils.grpc;
 
-import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
-import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
-import com.google.api.client.googleapis.util.Utils;
-import com.google.api.client.util.store.FileDataStoreFactory;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.auth.oauth2.UserCredentials;
+import io.grpc.Channel;
+
+import java.io.FileNotFoundException;
+import java.util.Iterator;
+
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
 import com.google.genomics.v1.ReferenceServiceV1Grpc;
 import com.google.genomics.v1.ReferenceServiceV1Grpc.ReferenceServiceV1BlockingStub;
 import com.google.genomics.v1.ReferenceSet;
@@ -19,46 +17,14 @@ import com.google.genomics.v1.StreamVariantsResponse;
 import com.google.genomics.v1.StreamingVariantServiceGrpc;
 import com.google.genomics.v1.StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub;
 
-import io.grpc.Channel;
-
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Iterator;
-
 public class Example {
-  private static GoogleCredentials getCreds() throws FileNotFoundException, IOException {
-      final String clientSecretsJson = "client_secrets.json";
+  public static void main(String[] args) throws Exception {
+    final String clientSecretsJson = "client_secrets.json";
+    GenomicsFactory.OfflineAuth auth = null;
     try {
-      final File userDir = new File(
-          System.getProperty("user.home"),
-          String.format(".store/%s", "gRPCExample"));
-      final GoogleClientSecrets secrets = GoogleClientSecrets.load(
-          Utils.getDefaultJsonFactory(), 
-          new FileReader(clientSecretsJson));
-      final GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow
-          .Builder(
-              Utils.getDefaultTransport(),
-              Utils.getDefaultJsonFactory(),
-              secrets,
-              Arrays.asList("https://www.googleapis.com/auth/genomics"))
-          .setDataStoreFactory(new FileDataStoreFactory(userDir))
-          .setAccessType("offline")
-          .setApprovalPrompt("force")
-          .build();
-      final AuthorizationCodeInstalledApp authCode = 
-          new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver());
-      Credential cred = authCode.authorize(System.getProperty("user.name"));
-      cred.refreshToken();
-      UserCredentials userCredentials = new UserCredentials(
-          secrets.getInstalled().getClientId(),
-          secrets.getInstalled().getClientSecret(),
-          cred.getRefreshToken());
-      
-      return userCredentials;
+      Builder builder =
+          GenomicsFactory.builder("gRPCExample");
+      auth = builder.build().getOfflineAuthFromClientSecretsFile(clientSecretsJson);
     } catch (FileNotFoundException fex) {
       System.out.println("Expecting to find " + clientSecretsJson +
           " file in " + 
@@ -66,17 +32,10 @@ public class Example {
           "Please make sure your project is whitelisted for gRPC access and\n" +
           "generate and download JSON key for your service account.\n" +
           "You can do that in API & Auth section of the Developer Console.");
-      return null;
-    }
-  }
-  
-  public static void main(String[] args) throws Exception {
-    GoogleCredentials creds = getCreds();
-    if (creds == null) {
       return;
     }
     
-    Channel channel = Channels.fromCreds(creds);
+    Channel channel = Channels.fromOfflineAuth(auth);
 
     // Regular RPC example: list all reference set assembly ids.
     ReferenceServiceV1BlockingStub refStub =
@@ -97,6 +56,7 @@ public class Example {
         .setStart(41196311)
         .setEnd(41277499)
         .build();
+
     Iterator<StreamVariantsResponse> iter = varStub.streamVariants(varRequest);
     while (iter.hasNext()) {
       StreamVariantsResponse varResponse = iter.next();

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
@@ -1,35 +1,60 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils.grpc;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Iterator;
+import java.util.List;
 
 import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ForwardingIterator;
+import com.google.common.collect.Iterables;
+import com.google.genomics.v1.Read;
 import com.google.genomics.v1.StreamReadsRequest;
 import com.google.genomics.v1.StreamReadsResponse;
 import com.google.genomics.v1.StreamingReadServiceGrpc;
 
 /**
- *  Class with tools for streaming reads via gRPC.
+ * Class with tools for streaming reads via gRPC.
  * 
  * TODO:
- * - facilitate shard boundary requirement https://github.com/googlegenomics/utils-java/issues/30
  * - facilitate partial requests https://github.com/googlegenomics/utils-java/issues/48
  */
 public class ReadStreamIterator extends ForwardingIterator<StreamReadsResponse> {
-
+  protected final Predicate<Read> shardPredicate;
   private Iterator<StreamReadsResponse> delegate;
 
   /**
-   * @param request
-   * @param auth
+   * Create a stream iterator that can enforce shard boundary semantics.
+   * 
+   * @param request The request for the shard of data.
+   * @param auth The OfflineAuth to use for the request.
+   * @param shardBoundary The shard boundary semantics to enforce.
+   * @param fields Which fields to include in a partial response or null for all.  NOT YET IMPLEMENTED.
    * @throws IOException
    * @throws GeneralSecurityException
    */
-  public ReadStreamIterator(StreamReadsRequest request, GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+  public ReadStreamIterator(StreamReadsRequest request, GenomicsFactory.OfflineAuth auth,
+      ShardBoundary.Requirement shardBoundary, String fields) throws IOException, GeneralSecurityException {
     // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
     // partial request.
+    shardPredicate = ShardBoundary.Requirement.STRICT == shardBoundary ?
+        ShardBoundary.getStrictReadPredicate(request.getStart()) :
+          null;
 
     StreamingReadServiceGrpc.StreamingReadServiceBlockingStub readStub =
         StreamingReadServiceGrpc.newBlockingStub(Channels.fromOfflineAuth(auth));
@@ -46,9 +71,15 @@ public class ReadStreamIterator extends ForwardingIterator<StreamReadsResponse> 
    * @see java.util.Iterator#next()
    */
   public StreamReadsResponse next() {
-    // TODO: Facilitate shard boundary predicate here by skipping any reads that overlap the
-    // start position.
-    return delegate.next();
+    StreamReadsResponse response = delegate.next();
+    if(null == shardPredicate) {
+      return response;
+    }
+    List<Read> reads = response.getAlignmentsList();
+    Iterable<Read> filteredReads = Iterables.filter(reads, shardPredicate);
+    return StreamReadsResponse.newBuilder(response)
+        .clearAlignments()
+        .addAllAlignments(filteredReads)
+        .build();
   }
-  
 }

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
@@ -1,42 +1,68 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils.grpc;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Iterator;
+import java.util.List;
 
 import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ForwardingIterator;
+import com.google.common.collect.Iterables;
 import com.google.genomics.v1.StreamVariantsRequest;
 import com.google.genomics.v1.StreamVariantsResponse;
 import com.google.genomics.v1.StreamingVariantServiceGrpc;
+import com.google.genomics.v1.Variant;
 
 /**
- *  Class with tools for streaming variants via gRPC.
+ * Class with tools for streaming variants via gRPC.
  * 
  * TODO:
- * - facilitate shard boundary requirement https://github.com/googlegenomics/utils-java/issues/30
  * - facilitate partial requests https://github.com/googlegenomics/utils-java/issues/48
  */
 public class VariantStreamIterator extends ForwardingIterator<StreamVariantsResponse> {
-
-  private Iterator<StreamVariantsResponse> delegate;
+  protected final Predicate<Variant> shardPredicate;
+  protected Iterator<StreamVariantsResponse> delegate;
 
   /**
-   * @param request
-   * @param auth
+   * Create a stream iterator that can enforce shard boundary semantics.
+   * 
+   * @param request The request for the shard of data.
+   * @param auth The OfflineAuth to use for the request.
+   * @param shardBoundary The shard boundary semantics to enforce.
+   * @param fields Which fields to include in a partial response or null for all.  NOT YET IMPLEMENTED.
    * @throws IOException
    * @throws GeneralSecurityException
    */
-  public VariantStreamIterator(StreamVariantsRequest request, GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+  public VariantStreamIterator(StreamVariantsRequest request, GenomicsFactory.OfflineAuth auth,
+      ShardBoundary.Requirement shardBoundary, String fields) throws IOException, GeneralSecurityException {
     // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
     // partial request.
-    
+    shardPredicate = ShardBoundary.Requirement.STRICT == shardBoundary ?
+        ShardBoundary.getStrictVariantPredicate(request.getStart()) :
+          null;
+
     StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub variantStub =
         StreamingVariantServiceGrpc.newBlockingStub(Channels.fromOfflineAuth(auth));
-    
+
+
     delegate = variantStub.streamVariants(request);
   }
-  
+
   @Override
   protected Iterator<StreamVariantsResponse> delegate() {
     return delegate;
@@ -46,9 +72,15 @@ public class VariantStreamIterator extends ForwardingIterator<StreamVariantsResp
    * @see java.util.Iterator#next()
    */
   public StreamVariantsResponse next() {
-    // TODO: Facilitate shard boundary predicate here by skipping any variants that overlap the
-    // start position.
-    return delegate.next();
+    StreamVariantsResponse response = delegate.next();
+    if(null == shardPredicate) {
+      return response;
+    }
+    List<Variant> variants = response.getVariantsList();
+    Iterable<Variant> filteredVariants = Iterables.filter(variants, shardPredicate);
+    return StreamVariantsResponse.newBuilder(response)
+        .clearVariants()
+        .addAllVariants(filteredVariants)
+        .build();
   }
-  
 }

--- a/src/test/java/com/google/cloud/genomics/utils/PaginatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/PaginatorTest.java
@@ -27,7 +27,7 @@ import com.google.api.services.genomics.model.SearchReadsResponse;
 import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.api.services.genomics.model.SearchVariantsResponse;
 import com.google.api.services.genomics.model.Variant;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary.Requirement;
 import com.google.common.collect.Lists;
 
 import org.hamcrest.CoreMatchers;
@@ -164,7 +164,7 @@ public class PaginatorTest {
     Mockito.when(variantsSearch.execute()).thenReturn(
         new SearchVariantsResponse().setVariants(Arrays.asList(input)));
 
-    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.STRICT);
+    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.Requirement.STRICT);
     List<Variant> filteredVariants = Lists.newArrayList();
     for (Variant variant : filteredPaginator.search(request)) {
       filteredVariants.add(variant);
@@ -184,7 +184,7 @@ public class PaginatorTest {
       fail("should have thrown an IllegalArgumentxception");
     } catch (IllegalArgumentException e) {} 
 
-    Paginator.Variants overlappingPaginator = Paginator.Variants.create(genomics, ShardBoundary.OVERLAPS);
+    Paginator.Variants overlappingPaginator = Paginator.Variants.create(genomics, ShardBoundary.Requirement.OVERLAPS);
     List<Variant> overlappingVariants = Lists.newArrayList();
     for (Variant variant : overlappingPaginator.search(request)) {
       overlappingVariants.add(variant);
@@ -209,7 +209,7 @@ public class PaginatorTest {
     Mockito.when(variantsSearch.execute()).thenReturn(
         new SearchVariantsResponse());
 
-    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.STRICT);
+    Paginator.Variants filteredPaginator = Paginator.Variants.create(genomics, ShardBoundary.Requirement.STRICT);
     assertNotNull(filteredPaginator.search(request));
   }
     
@@ -237,7 +237,7 @@ public class PaginatorTest {
     Mockito.when(readsSearch.execute()).thenReturn(
         new SearchReadsResponse().setAlignments(Arrays.asList(input)));
 
-    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.STRICT);
+    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.Requirement.STRICT);
     List<Read> filteredReads = Lists.newArrayList();
     for (Read read : filteredPaginator.search(request)) {
       filteredReads.add(read);
@@ -246,7 +246,7 @@ public class PaginatorTest {
     assertThat(filteredReads, CoreMatchers.hasItems(atStartWithinExtent,
         atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent));
 
-    Paginator.Reads overlappingPaginator = Paginator.Reads.create(genomics, ShardBoundary.OVERLAPS);
+    Paginator.Reads overlappingPaginator = Paginator.Reads.create(genomics, ShardBoundary.Requirement.OVERLAPS);
     List<Read> overlappingReads = Lists.newArrayList();
     for (Read read : overlappingPaginator.search(request)) {
       overlappingReads.add(read);
@@ -260,7 +260,7 @@ public class PaginatorTest {
     SearchReadsRequest request = new SearchReadsRequest().setStart(1000L).setEnd(2000L);
     Mockito.when(reads.search(request)).thenReturn(readsSearch);
 
-    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.STRICT);
+    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.Requirement.STRICT);
     thrown.expect(IllegalArgumentException.class);
     filteredPaginator.search(request, "nextPageToken,reads(id,alignment(cigar))").iterator().next();
   }
@@ -270,7 +270,7 @@ public class PaginatorTest {
     SearchReadsRequest request = new SearchReadsRequest().setStart(1000L).setEnd(2000L);
     Mockito.when(reads.search(request)).thenReturn(readsSearch);
 
-    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.STRICT);
+    Paginator.Reads filteredPaginator = Paginator.Reads.create(genomics, ShardBoundary.Requirement.STRICT);
     thrown.expect(IllegalArgumentException.class);
     filteredPaginator.search(request, "reads(id,alignment(cigar,position))").iterator().next();
   }
@@ -280,7 +280,7 @@ public class PaginatorTest {
     SearchReadsRequest request = new SearchReadsRequest().setStart(1000L).setEnd(2000L);
     Mockito.when(reads.search(request)).thenReturn(readsSearch);
 
-    Paginator.Reads overlappingPaginator = Paginator.Reads.create(genomics, ShardBoundary.OVERLAPS);
+    Paginator.Reads overlappingPaginator = Paginator.Reads.create(genomics, ShardBoundary.Requirement.OVERLAPS);
     thrown.expect(IllegalArgumentException.class);
     overlappingPaginator.search(request, "reads(id,alignment(cigar,position))").iterator().next();
   }

--- a/src/test/java/com/google/cloud/genomics/utils/ShardBoundaryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardBoundaryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.genomics.v1.LinearAlignment;
+import com.google.genomics.v1.Position;
+import com.google.genomics.v1.Read;
+import com.google.genomics.v1.Variant;
+
+
+public class ShardBoundaryTest {
+
+  @Test
+  public void testGetStrictVariantPredicate() {
+    long start = 1000L;
+    long end = 2000L;  // This is not used, but its the "extent" mentioned below.
+
+    Variant overlapStartWithinExtent = Variant.newBuilder().setStart(900L).setEnd(1005L).build();
+    Variant overlapStartExtent = Variant.newBuilder().setStart(999L).setEnd(5000L).build();
+    Variant atStartWithinExtent = Variant.newBuilder().setStart(1000L).setEnd(1002L).build();
+    Variant atStartOverlapExtent = Variant.newBuilder().setStart(1000L).setEnd(5000L).build();
+    Variant beyondStartWithinExtent = Variant.newBuilder().setStart(1500L).setEnd(1502L).build();
+    Variant beyondOverlapExtent = Variant.newBuilder().setStart(1500L).setEnd(5000L).build();
+    Variant[] variants = new Variant[] { overlapStartWithinExtent, overlapStartExtent, atStartWithinExtent,
+        atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent };
+
+    Predicate<Variant> shardPredicate = ShardBoundary.getStrictVariantPredicate(start); 
+    List<Variant> filteredVariants = Lists.newArrayList(Iterables.filter(Arrays.asList(variants), shardPredicate));
+    assertEquals(4, filteredVariants.size());
+    assertThat(filteredVariants, CoreMatchers.allOf(CoreMatchers.hasItems(atStartWithinExtent,
+        atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent)));
+  }
+
+  static Read readHelper(int start, int end) {
+    Position position = Position.newBuilder().setPosition((long) start).build();
+    LinearAlignment alignment = LinearAlignment.newBuilder().setPosition(position).build();
+    return Read.newBuilder().setAlignment(alignment).setFragmentLength(end-start).build();
+  }
+
+  @Test
+  public void testGetStrictReadPredicate() {
+    long start = 1000L;
+    long end = 2000L;  // This is not used, but its the "extent" mentioned below.
+
+      Read overlapStartWithinExtent = readHelper(900,1005);
+      Read overlapStartExtent = readHelper(999, 5000);
+      Read atStartWithinExtent = readHelper(1000, 1002);
+      Read atStartOverlapExtent = readHelper(1000, 5000);
+      Read beyondStartWithinExtent = readHelper(1500, 1502);
+      Read beyondOverlapExtent = readHelper(1500, 5000);
+      Read[] reads = new Read[] { overlapStartWithinExtent, overlapStartExtent, atStartWithinExtent,
+              atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent };
+
+      Predicate<Read> shardPredicate = ShardBoundary.getStrictReadPredicate(start); 
+      List<Read> filteredReads = Lists.newArrayList(Iterables.filter(Arrays.asList(reads), shardPredicate));
+      assertEquals(4, filteredReads.size());
+      assertThat(filteredReads, CoreMatchers.allOf(CoreMatchers.hasItems(atStartWithinExtent,
+          atStartOverlapExtent, beyondStartWithinExtent, beyondOverlapExtent)));
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -1,6 +1,21 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils.grpc;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -11,13 +26,16 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.cloud.genomics.utils.IntegrationTestHelper;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.genomics.v1.StreamReadsRequest;
 import com.google.genomics.v1.StreamReadsResponse;
 
-public class ReadStreamIteratorITCase {
 
+public class ReadStreamIteratorITCase {
+  // This small interval overlaps the Klotho SNP.
+  static final String REFERENCES = "chr13:33628134:33628138";
   static IntegrationTestHelper helper;
   
   @BeforeClass
@@ -29,7 +47,7 @@ public class ReadStreamIteratorITCase {
   public void testBasic() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
         ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
-        helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+        REFERENCES, 100L);
     assertEquals(1, requests.size());
     
     // TODO: switch this to helper.getAuth() to use api key once gRPC is no longer behind a whitelist.
@@ -38,11 +56,19 @@ public class ReadStreamIteratorITCase {
     // credentials do work fine on Google Compute Engine if running in a project in the whitelist.
     // https://github.com/googlegenomics/utils-java/issues/51
     Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0),
-        helper.getAuthWithUserCredentials());
+        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.OVERLAPS, null);
     
     assertTrue(iter.hasNext());
     StreamReadsResponse readResponse = iter.next();
-    assertEquals(55, readResponse.getAlignmentsList().size());
+    assertEquals(57, readResponse.getAlignmentsList().size());
+    assertFalse(iter.hasNext());
+
+    iter = new ReadStreamIterator(requests.get(0),
+        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.STRICT, null);
+    
+    assertTrue(iter.hasNext());
+    readResponse = iter.next();
+    assertEquals(2, readResponse.getAlignmentsList().size());
     assertFalse(iter.hasNext());
   }
 

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -1,34 +1,52 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.utils.grpc;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Iterator;
+import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.cloud.genomics.utils.IntegrationTestHelper;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.genomics.v1.StreamVariantsRequest;
 import com.google.genomics.v1.StreamVariantsResponse;
+import com.google.genomics.v1.Variant;
 
 public class VariantStreamIteratorITCase {
 
   static IntegrationTestHelper helper;
-  
+
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     helper = new IntegrationTestHelper();
   }
-  
+
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
         ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-        helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+            helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
 
     // TODO: switch this to helper.getAuth() to use api key once gRPC is no longer behind a whitelist.
@@ -37,11 +55,22 @@ public class VariantStreamIteratorITCase {
     // credentials do work fine on Google Compute Engine if running in a project in the whitelist.
     // https://github.com/googlegenomics/utils-java/issues/51
     Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0),
-        helper.getAuthWithUserCredentials());
+        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.OVERLAPS, null);
 
     assertTrue(iter.hasNext());
     StreamVariantsResponse variantResponse = iter.next();
-    assertEquals(4, variantResponse.getVariantsList().size());
+    List<Variant> variants = variantResponse.getVariantsList();
+    // This includes the klotho SNP and three non-variant segments which overlap it.
+    assertEquals(4, variants.size());
+    assertFalse(iter.hasNext());
+    
+    iter = new VariantStreamIterator(requests.get(0),
+        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.STRICT, null);
+
+    assertTrue(iter.hasNext());
+    variantResponse = iter.next();
+    // This includes only the klotho SNP.
+    assertEquals(1, variantResponse.getVariantsList().size());
     assertFalse(iter.hasNext());
   }
 


### PR DESCRIPTION
Also added placeholder parameter for future support for partial responses so that when support is added, clients will not need to update method signatures.

After this pull request, I think this refactor is at a good stopping point to merge to master.