### PR TITLE
Use an API Key for gRPC integration tests.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsChannel.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsChannel.java
@@ -32,7 +32,6 @@ import javax.net.ssl.SSLException;
 public class GenomicsChannel extends Channel {
   private static final String GENOMICS_ENDPOINT = "genomics.googleapis.com";
   private static final String GENOMICS_SCOPE = "https://www.googleapis.com/auth/genomics";
-  // TODO: This constant should come from grpc-java.
   private static final String API_KEY_HEADER = "X-Goog-Api-Key";
 
   // NOTE: Unfortunately we need to keep a handle to both of these since Channel does not expose
@@ -138,9 +137,8 @@ public class GenomicsChannel extends Channel {
   public static GenomicsChannel fromOfflineAuth(GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
     if(auth.hasUserCredentials()) {
       return fromCreds(auth.getUserCredentials());
-// TODO: https://github.com/googlegenomics/utils-java/issues/51      
-//    } else if(auth.hasApiKey()) {
-//      return new Channels(auth.apiKey);
+    } else if(auth.hasApiKey()) {
+      return fromApiKey(auth.apiKey);
     }
     // Fall back to Default Credentials if the user did not specify user credentials or an api key.
     return fromDefaultCreds();

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsChannel.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsChannel.java
@@ -33,6 +33,8 @@ public class GenomicsChannel extends Channel {
   private static final String GENOMICS_ENDPOINT = "genomics.googleapis.com";
   private static final String GENOMICS_SCOPE = "https://www.googleapis.com/auth/genomics";
   private static final String API_KEY_HEADER = "X-Goog-Api-Key";
+  // TODO https://github.com/googlegenomics/utils-java/issues/48
+  private static final String PARTIAL_RESPONSE_HEADER = "X-Goog-FieldMask";
 
   // NOTE: Unfortunately we need to keep a handle to both of these since Channel does not expose
   // the shutdown method and the ClientInterceptors do not return the ManagedChannel instance.
@@ -60,9 +62,9 @@ public class GenomicsChannel extends Channel {
   private GenomicsChannel(String apiKey) throws SSLException {
     managedChannel = getGenomicsManagedChannel();
     Metadata headers = new Metadata();
-    Metadata.Key<String> apiKeyHeaderKey =
+    Metadata.Key<String> apiKeyHeader =
         Metadata.Key.of(API_KEY_HEADER, Metadata.ASCII_STRING_MARSHALLER);
-    headers.put(apiKeyHeaderKey, apiKey);
+    headers.put(apiKeyHeader, apiKey);
     delegate = ClientInterceptors.intercept(managedChannel,
         MetadataUtils.newAttachHeadersInterceptor(headers)); 
   }

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -120,17 +120,4 @@ public class IntegrationTestHelper {
   public OfflineAuth getAuth() {
     return auth;
   }
-  
-  // TODO: Remove this whole method when gRPC is no longer behind a whitelist.  We really want to keep 
-  // integration tests to just API_KEY to keep them simple and only functional against public data.
-  // https://github.com/googlegenomics/utils-java/issues/51
-  public GenomicsFactory.OfflineAuth getAuthWithUserCredentials() throws GeneralSecurityException, IOException {
-    // This code is intentionally all in one method to make it easier to remove.
-    final String ENV_VAR = "GOOGLE_CLIENT_SECRETS_FILEPATH";
-    final String CLIENT_SECRECTS_FILEPATH = System.getenv(ENV_VAR);
-    assertNotNull("You must set the " + ENV_VAR + " environment variable for this test.", CLIENT_SECRECTS_FILEPATH);
-    
-    Builder builder = GenomicsFactory.builder(IntegrationTestHelper.class.getName());
-    return builder.build().getOfflineAuthFromClientSecretsFile(CLIENT_SECRECTS_FILEPATH);
-  }
 }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -15,22 +15,27 @@ package com.google.cloud.genomics.utils.grpc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.cloud.genomics.utils.IntegrationTestHelper;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.ImmutableList;
+import com.google.genomics.v1.Read;
 import com.google.genomics.v1.StreamReadsRequest;
 import com.google.genomics.v1.StreamReadsResponse;
+import com.google.genomics.v1.Variant;
 
 
 public class ReadStreamIteratorITCase {
@@ -65,6 +70,30 @@ public class ReadStreamIteratorITCase {
     readResponse = iter.next();
     assertEquals(2, readResponse.getAlignmentsList().size());
     assertFalse(iter.hasNext());
+  }
+
+  @Test
+  @Ignore
+  // TODO https://github.com/googlegenomics/utils-java/issues/48
+  public void testPartialResponses() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamReadsRequest> requests =
+        ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        REFERENCES, 100L);
+    assertEquals(1, requests.size());
+    
+    Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0),
+        helper.getAuth(), ShardBoundary.Requirement.STRICT, "reads(alignments)");
+    
+    assertTrue(iter.hasNext());
+    StreamReadsResponse readResponse = iter.next();
+    List<Read> reads = readResponse.getAlignmentsList();
+    assertEquals(2, reads.size());
+    assertFalse(iter.hasNext());
+    
+
+    assertEquals("chr13", reads.get(0).getAlignment().getPosition().getReferenceName());
+    assertEquals(33628134, reads.get(0).getAlignment().getPosition().getPosition());
+    assertNull(reads.get(0).getAlignedSequence());
   }
 
 }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -90,7 +90,6 @@ public class ReadStreamIteratorITCase {
     assertEquals(2, reads.size());
     assertFalse(iter.hasNext());
     
-
     assertEquals("chr13", reads.get(0).getAlignment().getPosition().getReferenceName());
     assertEquals(33628134, reads.get(0).getAlignment().getPosition().getPosition());
     assertNull(reads.get(0).getAlignedSequence());

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -50,13 +50,8 @@ public class ReadStreamIteratorITCase {
         REFERENCES, 100L);
     assertEquals(1, requests.size());
     
-    // TODO: switch this to helper.getAuth() to use api key once gRPC is no longer behind a whitelist.
-    // At that time, application default credentials would also work.  Right now application default credentials
-    // will not work locally since they come from a gcloud project not in the whitelist.  Application default
-    // credentials do work fine on Google Compute Engine if running in a project in the whitelist.
-    // https://github.com/googlegenomics/utils-java/issues/51
     Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0),
-        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.OVERLAPS, null);
+        helper.getAuth(), ShardBoundary.Requirement.OVERLAPS, null);
     
     assertTrue(iter.hasNext());
     StreamReadsResponse readResponse = iter.next();
@@ -64,7 +59,7 @@ public class ReadStreamIteratorITCase {
     assertFalse(iter.hasNext());
 
     iter = new ReadStreamIterator(requests.get(0),
-        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.STRICT, null);
+        helper.getAuth(), ShardBoundary.Requirement.STRICT, null);
     
     assertTrue(iter.hasNext());
     readResponse = iter.next();

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -49,13 +49,8 @@ public class VariantStreamIteratorITCase {
             helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
 
-    // TODO: switch this to helper.getAuth() to use api key once gRPC is no longer behind a whitelist.
-    // At that time, application default credentials would also work.  Right now application default credentials
-    // will not work locally since they come from a gcloud project not in the whitelist.  Application default
-    // credentials do work fine on Google Compute Engine if running in a project in the whitelist.
-    // https://github.com/googlegenomics/utils-java/issues/51
     Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0),
-        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.OVERLAPS, null);
+        helper.getAuth(), ShardBoundary.Requirement.OVERLAPS, null);
 
     assertTrue(iter.hasNext());
     StreamVariantsResponse variantResponse = iter.next();
@@ -65,7 +60,7 @@ public class VariantStreamIteratorITCase {
     assertFalse(iter.hasNext());
     
     iter = new VariantStreamIterator(requests.get(0),
-        helper.getAuthWithUserCredentials(), ShardBoundary.Requirement.STRICT, null);
+        helper.getAuth(), ShardBoundary.Requirement.STRICT, null);
 
     assertTrue(iter.hasNext());
     variantResponse = iter.next();

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -15,6 +15,7 @@ package com.google.cloud.genomics.utils.grpc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -23,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.cloud.genomics.utils.IntegrationTestHelper;
@@ -67,6 +69,30 @@ public class VariantStreamIteratorITCase {
     // This includes only the klotho SNP.
     assertEquals(1, variantResponse.getVariantsList().size());
     assertFalse(iter.hasNext());
+  }
+
+  @Test
+  @Ignore
+  // TODO https://github.com/googlegenomics/utils-java/issues/48
+  public void testPartialResponses() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+            helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+    assertEquals(1, requests.size());
+
+    Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0),
+        helper.getAuth(), ShardBoundary.Requirement.STRICT, "variants(reference_name,start)");
+
+    assertTrue(iter.hasNext());
+    StreamVariantsResponse variantResponse = iter.next();
+    List<Variant> variants = variantResponse.getVariantsList();
+    // This includes only the klotho SNP.
+    assertEquals(1, variants.size());
+    assertFalse(iter.hasNext());
+    
+    assertEquals("chr13", variants.get(0).getReferenceName());
+    assertEquals(33628137, variants.get(0).getStart());
+    assertNull(variants.get(0).getReferenceBases());
   }
 
 }


### PR DESCRIPTION
Closes https://github.com/googlegenomics/utils-java/issues/51

API Key must come from a whitelisted project.  If not, the error is "io.grpc.StatusRuntimeException: NOT_FOUND: Method not found." as expected.