### PR TITLE
Move VariantUtils from dataflow-java to utils-java.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/VariantUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import java.util.Comparator;
+import java.util.List;
+
+import com.google.api.services.genomics.model.Call;
+import com.google.api.services.genomics.model.Variant;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
+
+public class VariantUtils {
+
+  public static final String GATK_NON_VARIANT_SEGMENT_ALT = "<NON_REF>";
+
+  /**
+   * Determine whether the variant has any values in alternate bases.
+   */
+  public static final Predicate<Variant> HAS_ALTERNATE = new Predicate<Variant>() {
+    @Override
+    public boolean apply(Variant variant) {
+      List<String> alternateBases = variant.getAlternateBases();
+      return !(null == alternateBases || alternateBases.isEmpty());
+    }
+  };
+
+  public static final Predicate<String> LENGTH_IS_1 = Predicates.compose(Predicates.equalTo(1),
+      new Function<String, Integer>() {
+        @Override
+        public Integer apply(String string) {
+          return string.length();
+        }
+      });
+
+  /**
+   * Determine whether the variant is a SNP.
+   */
+  public static final Predicate<Variant> IS_SNP = Predicates.and(HAS_ALTERNATE,
+      new Predicate<Variant>() {
+        @Override
+        public boolean apply(Variant variant) {
+          return LENGTH_IS_1.apply(variant.getReferenceBases())
+              && Iterables.all(variant.getAlternateBases(), LENGTH_IS_1);
+        }
+      });
+
+  /**
+   * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
+   *
+   * For Complete Genomics data and gVCFs such as Platinum Genomes, we wind up with zero alternates
+   * (the missing value indicator "." in the VCF ALT field gets converted to null). See
+   * https://sites.google.com/site/gvcftools/home/about-gvcf for more detail.
+   */
+  public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT_WITH_MISSING_ALT = Predicates.and(
+      Predicates.not(HAS_ALTERNATE), new Predicate<Variant>() {
+        @Override
+        public boolean apply(Variant variant) {
+          // The same deletion can be specified as [CAG -> C] or [AG -> null], so double check that
+          // the reference bases are also of length 1 when there are no alternates.
+          return LENGTH_IS_1.apply(variant.getReferenceBases());
+        }
+      });
+
+  /**
+   * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
+   *
+   * For data processed by GATK the value of ALT is "&lt;NON_REF&gt;". See
+   * https://www.broadinstitute.org/gatk/guide/article?id=4017 for more detail.
+   */
+  public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT = Predicates.and(
+      HAS_ALTERNATE, new Predicate<Variant>() {
+        @Override
+        public boolean apply(Variant variant) {
+          return Iterables.all(variant.getAlternateBases(),
+              Predicates.equalTo(GATK_NON_VARIANT_SEGMENT_ALT));
+        }
+      });
+
+  /**
+   * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
+   */
+  public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT = Predicates.or(
+      IS_NON_VARIANT_SEGMENT_WITH_MISSING_ALT, IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT);
+
+
+  /**
+   * Comparator for sorting calls by call set name.
+   */
+  public static final Comparator<Call> CALL_COMPARATOR = Ordering.natural().onResultOf(
+      new Function<Call, String>() {
+        @Override
+        public String apply(Call call) {
+          return call.getCallSetName();
+        }
+      });
+}

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils.grpc;
+
+import java.util.List;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.genomics.v1.Variant;
+
+public class VariantUtils {
+
+  public static final String GATK_NON_VARIANT_SEGMENT_ALT = "<NON_REF>";
+
+  /**
+   * Determine whether the variant has any values in alternate bases.
+   */
+  public static final Predicate<Variant> HAS_ALTERNATE = new Predicate<Variant>() {
+    @Override
+    public boolean apply(Variant variant) {
+      List<String> alternateBases = variant.getAlternateBasesList();
+      return !(null == alternateBases || alternateBases.isEmpty());
+    }
+  };
+
+  public static final Predicate<String> LENGTH_IS_1 = Predicates.compose(Predicates.equalTo(1),
+      new Function<String, Integer>() {
+        @Override
+        public Integer apply(String string) {
+          return string.length();
+        }
+      });
+
+  /**
+   * Determine whether the variant is a SNP.
+   */
+  public static final Predicate<Variant> IS_SNP = Predicates.and(HAS_ALTERNATE,
+      new Predicate<Variant>() {
+        @Override
+        public boolean apply(Variant variant) {
+          return LENGTH_IS_1.apply(variant.getReferenceBases())
+              && Iterables.all(variant.getAlternateBasesList(), LENGTH_IS_1);
+        }
+      });
+
+  /**
+   * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
+   *
+   * For Complete Genomics data and gVCFs such as Platinum Genomes, we wind up with zero alternates
+   * (the missing value indicator "." in the VCF ALT field gets converted to null). See
+   * https://sites.google.com/site/gvcftools/home/about-gvcf for more detail.
+   */
+  public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT_WITH_MISSING_ALT = Predicates.and(
+      Predicates.not(HAS_ALTERNATE), new Predicate<Variant>() {
+        @Override
+        public boolean apply(Variant variant) {
+          // The same deletion can be specified as [CAG -> C] or [AG -> null], so double check that
+          // the reference bases are also of length 1 when there are no alternates.
+          return LENGTH_IS_1.apply(variant.getReferenceBases());
+        }
+      });
+
+  /**
+   * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
+   *
+   * For data processed by GATK the value of ALT is "&lt;NON_REF&gt;". See
+   * https://www.broadinstitute.org/gatk/guide/article?id=4017 for more detail.
+   */
+  public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT = Predicates.and(
+      HAS_ALTERNATE, new Predicate<Variant>() {
+        @Override
+        public boolean apply(Variant variant) {
+          return Iterables.all(variant.getAlternateBasesList(),
+              Predicates.equalTo(GATK_NON_VARIANT_SEGMENT_ALT));
+        }
+      });
+
+  /**
+   * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
+   */
+  public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT = Predicates.or(
+      IS_NON_VARIANT_SEGMENT_WITH_MISSING_ALT, IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT);
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/TestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/TestHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.api.services.genomics.model.Call;
+import com.google.api.services.genomics.model.Variant;
+
+public class TestHelper {
+
+  public static Call makeCall(String name, Integer... alleles) {
+    return new Call().setCallSetName(name).setGenotype(Arrays.asList(alleles));
+  }
+
+  public static Variant makeSimpleVariant(Call... calls) {
+    return new Variant().setCalls(Arrays.asList(calls));
+  }
+
+  public static Variant makeVariant(String referenceName, long start, long end,
+      String referenceBases, List<String> alternateBases, Call... calls) {
+    Variant variant =
+        new Variant().setReferenceName(referenceName).setStart(start).setEnd(end)
+            .setReferenceBases(referenceBases).setAlternateBases(alternateBases);
+    if (null != calls) {
+      variant.setCalls(Arrays.asList(calls));
+    }
+    return variant;
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/VariantUtilsTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.google.api.services.genomics.model.Call;
+
+public class VariantUtilsTest {
+
+  private List<String> emptyAlt = Arrays.asList();
+
+  @Test
+  public void testIsVariant() {
+    // SNPs
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", Arrays.asList("C"), (Call[]) null)));
+
+    // Insertions
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", Arrays.asList("AC"), (Call[]) null)));
+
+    // Deletions NOTE: These are all the same mutation, just encoded in different ways.
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "CAG", Arrays.asList("C"), (Call[]) null)));
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "AG", emptyAlt, (Call[]) null)));
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "AG", null, (Call[]) null)));
+
+    // Multi-allelic sites
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", Arrays.asList("C", "AC"), (Call[]) null)));
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", Arrays.asList("C", "G"), (Call[]) null)));
+
+    // Non-Variant Block Records
+    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", emptyAlt, (Call[]) null)));
+    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", null, (Call[]) null)));
+    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+        200001, "A", Arrays.asList(VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT), (Call[]) null)));
+  }
+
+  @Test
+  public void testIsSNP() {
+    assertTrue(VariantUtils.IS_SNP.apply(TestHelper.makeVariant("chr7", 200000, 200001, "A",
+        Arrays.asList("C"), (Call[]) null)));
+    // Deletion
+    assertFalse(VariantUtils.IS_SNP.apply(TestHelper.makeVariant("chr7", 200000, 200001, "CA",
+        Arrays.asList("C"), (Call[]) null)));
+    // Insertion
+    assertFalse(VariantUtils.IS_SNP.apply(TestHelper.makeVariant("chr7", 200000, 200001, "C",
+        Arrays.asList("CA"), (Call[]) null)));
+
+    // SNP and Insertion
+    assertFalse(VariantUtils.IS_SNP.apply(TestHelper.makeVariant("chr7", 200000, 200001, "C",
+        Arrays.asList("A", "CA"), (Call[]) null)));
+
+    // Block Records
+    assertFalse(VariantUtils.IS_SNP.apply(TestHelper.makeVariant("chr7", 200000, 200001, "A",
+        emptyAlt, (Call[]) null)));
+    assertFalse(VariantUtils.IS_SNP.apply(TestHelper.makeVariant("chr7", 200000, 200001, "A", null,
+        (Call[]) null)));
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantUtilsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils.grpc;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.google.genomics.v1.Variant;
+
+public class VariantUtilsTest {
+
+  @Test
+  public void testIsSNP() {
+    assertTrue(VariantUtils.IS_SNP.apply(Variant.newBuilder().setReferenceName("chr7")
+        .setStart(200000).setEnd(200001).setReferenceBases("A").addAlternateBases("C").build()));
+
+    // Deletion
+    assertFalse(VariantUtils.IS_SNP.apply(Variant.newBuilder().setReferenceName("chr7")
+        .setStart(200000).setEnd(200001).setReferenceBases("CA").addAlternateBases("C").build()));
+
+    // Insertion
+    assertFalse(VariantUtils.IS_SNP.apply(Variant.newBuilder().setReferenceName("chr7")
+        .setStart(200000).setEnd(200001).setReferenceBases("C").addAlternateBases("CA").build()));
+
+    // SNP and Insertion
+    assertFalse(VariantUtils.IS_SNP.apply(Variant.newBuilder().setReferenceName("chr7")
+        .setStart(200000).setEnd(200001).setReferenceBases("C").addAlternateBases("A")
+        .addAlternateBases("CA").build()));
+
+    // Block Records
+    assertFalse(VariantUtils.IS_SNP.apply(Variant.newBuilder().setReferenceName("chr7")
+        .setStart(200000).setEnd(200001).setReferenceBases("A").build()));
+    assertFalse(VariantUtils.IS_SNP.apply(Variant.newBuilder().setReferenceName("chr7")
+        .setStart(200000).setEnd(200001).setReferenceBases("A")
+        .addAlternateBases(VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT).build()));
+  }
+
+  @Test
+  public void testIsVariant() {
+    // SNPs
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A")
+        .addAlternateBases("C").build()));
+
+    // Insertions
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A")
+        .addAlternateBases("AC").build()));
+
+    // Deletions NOTE: These are all the same mutation, just encoded in different ways.
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("CAG")
+        .addAlternateBases("C").build()));
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("AG").build()));
+
+    // Multi-allelic sites
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A")
+        .addAlternateBases("C").addAlternateBases("AC").build()));
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A")
+        .addAlternateBases("C").addAlternateBases("G").build()));
+
+    // Non-Variant Block Records
+    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A").build()));
+    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
+        .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A")
+        .addAlternateBases(VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT).build()));
+  }
+}


### PR DESCRIPTION
Also add v1 equivalents as needed.

Note that this goes along with:
* add a v1 version of  JoinNonVariantSegmentsWithVariants https://github.com/deflaux/dataflow-java/commit/d3949e045941ffab9f01127eecfd49e7060e1a6e
* port variant transformation pipeline to gRPC https://github.com/deflaux/codelabs/commit/dc0e0f26404463b3fe8e37090f369d01a65b3756 which will stay in a branch until gRPC is no longer behind a whitelist