### PR TITLE
Add retrying of gRPC streams.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
@@ -33,6 +33,8 @@ import com.google.common.collect.Lists;
  * Includes complex retry logic to upon failure resume the stream at the last known good start
  * position without returning duplicate data.
  * 
+ * TODO: refactor this further to simplify the generic signature. 
+ * 
  * @param <Request> Streaming request type.
  * @param <Response> Streaming response type.
  * @param <Item> Genomic data type returned by stream.

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils.grpc;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.api.client.util.BackOff;
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ForwardingIterator;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+/**
+ * An iterator for streaming genomic data via gRPC with shard boundary semantics.
+ * 
+ * Includes complex retry logic to upon failure resume the stream at the last known good start
+ * position without returning duplicate data.
+ * 
+ * @param <A> Streaming request type.
+ * @param <B> Streaming response type.
+ * @param <C> Genomic data type returned by stream.
+ * @param <D> Blocking stub type.
+ */
+public abstract class GenomicsStreamIterator<A, B, C, D extends io.grpc.stub.AbstractStub<D>> extends ForwardingIterator<B> {
+  private static final Logger LOG = Logger.getLogger(GenomicsStreamIterator.class.getName());
+  private final ExponentialBackOff backoff;
+  protected final D stub;
+  protected final GenomicsChannel genomicsChannel;
+  protected final A originalRequest;
+
+  // For client-side enforcement of a strict shard boundary.
+  protected Predicate<C> shardPredicate;
+
+  // Stateful members used to facilitate complex retry behavior for gRPC streams.
+  private Iterator<B> delegate;
+  private C lastSuccessfulDataItem;
+  private String idSentinel;
+
+  /**
+   * Create a stream iterator that can enforce shard boundary semantics and perform retries.
+   * 
+   * @param request The request for the shard of data.
+   * @param auth The OfflineAuth to use for the request.
+   * @param shardBoundary The shard boundary semantics to enforce.
+   * @param fields Which fields to include in a partial response or null for all. NOT YET
+   *        IMPLEMENTED.
+   * @throws IOException
+   * @throws GeneralSecurityException
+   */
+  public GenomicsStreamIterator(A request, GenomicsFactory.OfflineAuth auth,
+      ShardBoundary.Requirement shardBoundary, String fields) throws IOException,
+      GeneralSecurityException {
+    this.originalRequest = request;
+    genomicsChannel = GenomicsChannel.fromOfflineAuth(auth);
+    stub = createStub(genomicsChannel);
+
+    // Using default backoff settings. For details, see
+    // https://developers.google.com/api-client-library/java/google-http-java-client/reference/1.19.0/com/google/api/client/util/ExponentialBackOff
+    backoff = new ExponentialBackOff.Builder().build();
+
+    // RETRY STATE: Initialize settings.
+    delegate = createIterator(originalRequest);
+    lastSuccessfulDataItem = null;
+    idSentinel = null;
+  }
+
+  abstract D createStub(GenomicsChannel genomicsChannel);
+
+  abstract Iterator<B> createIteratorFromStub(A request);
+
+  abstract long getRequestStart(A streamRequest);
+
+  abstract long getDataItemStart(C dataItem);
+
+  abstract String getDataItemId(C dataItem);
+
+  abstract A getRevisedRequest(long updatedStart);
+
+  abstract List<C> getDataList(B response);
+
+  abstract B setDataList(B response, Iterable<C> dataList);
+
+  private Iterator<B> createIterator(A request) {
+    while (true) {
+      try {
+        return createIteratorFromStub(request);
+      } catch (Exception e) {
+        if (shouldRetryNow()) {
+          LOG.log(Level.WARNING, "Retrying after failure to create iterator", e);
+        } else {
+          LOG.log(Level.WARNING, "All retries to create iterator consumed, re-throwing exception",
+              e);
+          throw e;
+        }
+      }
+    }
+  }
+
+  private boolean shouldRetryNow() {
+    long backOffMillis;
+    try {
+      backOffMillis = backoff.nextBackOffMillis();
+    } catch (IOException e1) {
+      // Something strange happened, just give up.
+      backOffMillis = BackOff.STOP;
+    }
+
+    if (backOffMillis == BackOff.STOP) {
+      backoff.reset();
+      return false;
+    }
+
+    try {
+      Thread.sleep(backOffMillis);
+    } catch (InterruptedException e) {
+      LOG.log(Level.WARNING, "Backoff sleep interrupted", e);
+    }
+    return true;
+  }
+
+  @Override
+  protected Iterator<B> delegate() {
+    return delegate;
+  }
+
+  /**
+   * @see java.util.Iterator#hasNext()
+   */
+  public boolean hasNext() {
+    boolean hasNext;
+    while (true) {
+      try {
+        hasNext = delegate.hasNext();
+        break;
+      } catch (Exception e) {
+        if (shouldRetryNow()) {
+          LOG.log(Level.WARNING, "Retrying after failing to get next item from stream: ", e);
+          setStreamStateForRetry();
+        } else {
+          LOG.log(Level.WARNING, "All retries to get next item from stream consumed, throwing: ", e);
+          genomicsChannel.shutdownNow();
+          throw e;
+        }
+      }
+    }
+    if (!hasNext) {
+      genomicsChannel.shutdownNow();
+    }
+    return hasNext;
+  }
+
+  private void setStreamStateForRetry() {
+    if (null == lastSuccessfulDataItem) {
+      // We have never returned any data. No need to set up state needed to filter previously
+      // returned results.
+      return;
+    }
+
+    if (getRequestStart(originalRequest) < getDataItemStart(lastSuccessfulDataItem)) {
+      // Create a new iterator at the revised start position.
+      delegate = createIterator(getRevisedRequest(getDataItemStart(lastSuccessfulDataItem)));
+    } else {
+      // The point at which the retry occurred was still within data overlapping the start of our
+      // original request but not beyond it yet.
+      delegate = createIterator(originalRequest);
+    }
+
+    // RETRY STATE: Enable the filtering of repeated data in next().
+    idSentinel = getDataItemId(lastSuccessfulDataItem);
+  }
+
+  /**
+   * @see java.util.Iterator#next()
+   */
+  public B next() {
+    B response = delegate.next();
+    // TODO: Its more clean conceptually to do the same thing for all responses, but this could be a
+    // place where we're wasting a lot of time rebuilding response objects when nothing has actually
+    // changed.
+    return setDataList(response, enforceShardPredicate(removeRepeatedData(getDataList(response))));
+  }
+
+  private List<C> removeRepeatedData(List<C> dataList) {
+    List<C> filteredDataList = null;
+    if (null == idSentinel) {
+      filteredDataList = dataList;
+    } else {
+      // Filter out previously returned data items.
+      filteredDataList = Lists.newArrayList();
+      boolean sentinelFound = false;
+      for (C dataItem : dataList) {
+        if (sentinelFound) {
+          filteredDataList.add(dataItem);
+        } else {
+          if (idSentinel.equals(getDataItemId(dataItem))) {
+            // RETRY STATE: We're at the end of the repeated data. Unset the sentinel and proceed.
+            idSentinel = null;
+            sentinelFound = true;
+          }
+        }
+      }
+    }
+    // RETRY STATE: Keep our last successfully returned data item in memory, just in case we need to
+    // retry.
+    if (filteredDataList.size() > 0) {
+      lastSuccessfulDataItem = filteredDataList.get(filteredDataList.size() - 1);
+    }
+    return filteredDataList;
+  }
+
+  private Iterable<C> enforceShardPredicate(Iterable<C> dataList) {
+    if (null == shardPredicate) {
+      return dataList;
+    }
+    // DEV NOTE: right now there is only one possible predicate and it only matters for
+    // the beginning of the shard. An optimization would be to get rid of the predicate once
+    // we are beyond that boundary. BUT this predicate could be something more complicated in
+    // the future (e.g., enforce a shard boundary AND only return SNPs, etc...).
+    return Iterables.filter(dataList, shardPredicate);
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
@@ -21,6 +21,7 @@ import java.util.List;
 import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardBoundary.Requirement;
+import com.google.common.base.Predicate;
 import com.google.genomics.v1.Read;
 import com.google.genomics.v1.StreamReadsRequest;
 import com.google.genomics.v1.StreamReadsResponse;
@@ -42,22 +43,39 @@ public class ReadStreamIterator
   /**
    * Create a stream iterator that can enforce shard boundary semantics.
    * 
-   * @param request The request for the shard of data.
-   * @param auth The OfflineAuth to use for the request.
-   * @param shardBoundary The shard boundary semantics to enforce.
-   * @param fields Which fields to include in a partial response or null for all. NOT YET
-   *        IMPLEMENTED.
+   * @param request
+   * @param auth
+   * @param shardBoundary
+   * @param fields
    * @throws IOException
    * @throws GeneralSecurityException
    */
-  public ReadStreamIterator(StreamReadsRequest request, OfflineAuth auth,
-      Requirement shardBoundary, String fields) throws IOException, GeneralSecurityException {
-    super(request, auth, shardBoundary, fields);
-    // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
-    // partial request.
-    shardPredicate =
+  public static ReadStreamIterator enforceShardBoundary(StreamReadsRequest request,
+      OfflineAuth auth, Requirement shardBoundary, String fields) throws IOException,
+      GeneralSecurityException {
+    Predicate<Read> shardPredicate =
         (ShardBoundary.Requirement.STRICT == shardBoundary) ? ShardBoundary
             .getStrictReadPredicate(request.getStart()) : null;
+    // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
+    // partial request.
+    return new ReadStreamIterator(request, auth, fields, shardPredicate);
+  }
+
+  /**
+   * Create a stream iterator.
+   * 
+   * @param request The request for the shard of data.
+   * @param auth The OfflineAuth to use for the request.
+   * @param fields Which fields to include in a partial response or null for all. NOT YET
+   *        IMPLEMENTED.
+   * @param shardPredicate A predicate used to client-side filter results returned (e.g., enforce
+   *             a shard boundary and/or limit to SNPs only) or null for no filtering.
+   * @throws IOException
+   * @throws GeneralSecurityException
+   */
+  public ReadStreamIterator(StreamReadsRequest request, OfflineAuth auth, String fields,
+      Predicate<Read> shardPredicate) throws IOException, GeneralSecurityException {
+    super(request, auth, fields, shardPredicate);
   }
 
   @Override
@@ -96,7 +114,7 @@ public class ReadStreamIterator
   }
 
   @Override
-  StreamReadsResponse setDataList(StreamReadsResponse response, Iterable<Read> dataList) {
+  StreamReadsResponse buildResponse(StreamReadsResponse response, Iterable<Read> dataList) {
     return StreamReadsResponse.newBuilder(response).clearAlignments()
         .addAllAlignments(dataList)
         .build();

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
@@ -18,26 +18,26 @@ import java.security.GeneralSecurityException;
 import java.util.Iterator;
 import java.util.List;
 
-import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
 import com.google.cloud.genomics.utils.ShardBoundary;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ForwardingIterator;
-import com.google.common.collect.Iterables;
+import com.google.cloud.genomics.utils.ShardBoundary.Requirement;
 import com.google.genomics.v1.StreamVariantsRequest;
 import com.google.genomics.v1.StreamVariantsResponse;
 import com.google.genomics.v1.StreamingVariantServiceGrpc;
+import com.google.genomics.v1.StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub;
 import com.google.genomics.v1.Variant;
 
 /**
- * Class with tools for streaming variants via gRPC.
+ * An iterator for streaming genomic variants via gRPC with shard boundary semantics.
  * 
- * TODO:
- * - facilitate partial requests https://github.com/googlegenomics/utils-java/issues/48
+ * Includes complex retry logic to upon failure resume the stream at the last known good start
+ * position without returning duplicate data.
+ * 
+ * TODO: - facilitate partial requests https://github.com/googlegenomics/utils-java/issues/48
  */
-public class VariantStreamIterator extends ForwardingIterator<StreamVariantsResponse> {
-  protected final Predicate<Variant> shardPredicate;
-  protected final Iterator<StreamVariantsResponse> delegate;
-  protected final GenomicsChannel genomicsChannel;
+public class VariantStreamIterator
+    extends
+    GenomicsStreamIterator<StreamVariantsRequest, StreamVariantsResponse, Variant, StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub> {
 
   /**
    * Create a stream iterator that can enforce shard boundary semantics.
@@ -45,68 +45,59 @@ public class VariantStreamIterator extends ForwardingIterator<StreamVariantsResp
    * @param request The request for the shard of data.
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.
-   * @param fields Which fields to include in a partial response or null for all.  NOT YET IMPLEMENTED.
+   * @param fields Which fields to include in a partial response or null for all. NOT YET
+   *        IMPLEMENTED.
    * @throws IOException
    * @throws GeneralSecurityException
    */
-  public VariantStreamIterator(StreamVariantsRequest request, GenomicsFactory.OfflineAuth auth,
-      ShardBoundary.Requirement shardBoundary, String fields) throws IOException, GeneralSecurityException {
+  public VariantStreamIterator(StreamVariantsRequest request, OfflineAuth auth,
+      Requirement shardBoundary, String fields) throws IOException, GeneralSecurityException {
+    super(request, auth, shardBoundary, fields);
     // TODO: Facilitate shard boundary predicate here by checking for minimum set of fields in
     // partial request.
-    shardPredicate = ShardBoundary.Requirement.STRICT == shardBoundary ?
-        ShardBoundary.getStrictVariantPredicate(request.getStart()) :
-          null;
-
-    genomicsChannel = GenomicsChannel.fromOfflineAuth(auth);
-    StreamingVariantServiceGrpc.StreamingVariantServiceBlockingStub variantStub =
-        StreamingVariantServiceGrpc.newBlockingStub(genomicsChannel);
-
-
-    delegate = variantStub.streamVariants(request);
+    shardPredicate =
+        (ShardBoundary.Requirement.STRICT == shardBoundary) ? ShardBoundary
+            .getStrictVariantPredicate(request.getStart()) : null;
   }
 
   @Override
-  protected Iterator<StreamVariantsResponse> delegate() {
-    return delegate;
+  StreamingVariantServiceBlockingStub createStub(GenomicsChannel genomicsChannel) {
+    return StreamingVariantServiceGrpc.newBlockingStub(genomicsChannel);
   }
 
-  /**
-   * @see java.util.Iterator#hasNext()
-   */
-  public boolean hasNext() {
-    boolean hasNext;
-    try {
-      hasNext = delegate.hasNext();
-    } catch (Exception e) {
-      genomicsChannel.shutdownNow();
-      throw e;
-    }
-    if(!hasNext) {
-      genomicsChannel.shutdownNow();      
-    }
-    return hasNext;
+  @Override
+  Iterator<StreamVariantsResponse> createIteratorFromStub(StreamVariantsRequest request) {
+    return stub.streamVariants(request);
   }
 
-  /**
-   * @see java.util.Iterator#next()
-   */
-  public StreamVariantsResponse next() {
-    StreamVariantsResponse response = null;
-    try {
-      response = delegate.next();
-    } catch (Exception e) {
-      genomicsChannel.shutdownNow();
-      throw e;
-    }
+  @Override
+  long getRequestStart(StreamVariantsRequest request) {
+    return request.getStart();
+  }
 
-    if(null == shardPredicate) {
-      return response;
-    }
-    List<Variant> variants = response.getVariantsList();
-    Iterable<Variant> filteredVariants = Iterables.filter(variants, shardPredicate);
-    return StreamVariantsResponse.newBuilder(response)
-        .clearVariants()
-        .addAllVariants(filteredVariants)
+  @Override
+  long getDataItemStart(Variant dataItem) {
+    return dataItem.getStart();
+  }
+
+  @Override
+  String getDataItemId(Variant dataItem) {
+    return dataItem.getId();
+  }
+
+  @Override
+  StreamVariantsRequest getRevisedRequest(long updatedStart) {
+    return StreamVariantsRequest.newBuilder(originalRequest).setStart(updatedStart).build();
+  }
+
+  @Override
+  List<Variant> getDataList(StreamVariantsResponse response) {
+    return response.getVariantsList();
+  }
+
+  @Override
+  StreamVariantsResponse setDataList(StreamVariantsResponse response, Iterable<Variant> dataList) {
+    return StreamVariantsResponse.newBuilder(response).clearVariants().addAllVariants(dataList)
         .build();
   }
 }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -55,15 +55,16 @@ public class ReadStreamIteratorITCase {
         REFERENCES, 100L);
     assertEquals(1, requests.size());
     
-    Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0),
-        helper.getAuth(), ShardBoundary.Requirement.OVERLAPS, null);
+    Iterator<StreamReadsResponse> iter =
+        ReadStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.OVERLAPS, null);
     
     assertTrue(iter.hasNext());
     StreamReadsResponse readResponse = iter.next();
     assertEquals(57, readResponse.getAlignmentsList().size());
     assertFalse(iter.hasNext());
 
-    iter = new ReadStreamIterator(requests.get(0),
+    iter = ReadStreamIterator.enforceShardBoundary(requests.get(0),
         helper.getAuth(), ShardBoundary.Requirement.STRICT, null);
     
     assertTrue(iter.hasNext());
@@ -81,8 +82,9 @@ public class ReadStreamIteratorITCase {
         REFERENCES, 100L);
     assertEquals(1, requests.size());
     
-    Iterator<StreamReadsResponse> iter = new ReadStreamIterator(requests.get(0),
-        helper.getAuth(), ShardBoundary.Requirement.STRICT, "reads(alignments)");
+    Iterator<StreamReadsResponse> iter =
+        ReadStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.STRICT, "reads(alignments)");
     
     assertTrue(iter.hasNext());
     StreamReadsResponse readResponse = iter.next();

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -51,8 +51,9 @@ public class VariantStreamIteratorITCase {
             helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
 
-    Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0),
-        helper.getAuth(), ShardBoundary.Requirement.OVERLAPS, null);
+    Iterator<StreamVariantsResponse> iter =
+        VariantStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.OVERLAPS, null);
 
     assertTrue(iter.hasNext());
     StreamVariantsResponse variantResponse = iter.next();
@@ -61,8 +62,9 @@ public class VariantStreamIteratorITCase {
     assertEquals(4, variants.size());
     assertFalse(iter.hasNext());
     
-    iter = new VariantStreamIterator(requests.get(0),
-        helper.getAuth(), ShardBoundary.Requirement.STRICT, null);
+    iter =
+        VariantStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.STRICT, null);
 
     assertTrue(iter.hasNext());
     variantResponse = iter.next();
@@ -80,8 +82,9 @@ public class VariantStreamIteratorITCase {
             helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
 
-    Iterator<StreamVariantsResponse> iter = new VariantStreamIterator(requests.get(0),
-        helper.getAuth(), ShardBoundary.Requirement.STRICT, "variants(reference_name,start)");
+    Iterator<StreamVariantsResponse> iter =
+        VariantStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.STRICT, "variants(reference_name,start)");
 
     assertTrue(iter.hasNext());
     StreamVariantsResponse variantResponse = iter.next();

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -98,4 +98,18 @@ public class VariantStreamIteratorITCase {
     assertNull(variants.get(0).getReferenceBases());
   }
 
+  // TODO test a shard where the entire first result will be empty due to the strict shard boundary requirement.  Same for reads.
+  
+  /**
+   * TODO: Retry tests.  Same for reads.
+   * 
+   * Be sure to test retries that occur at:
+   * (1) the beginning of the stream
+   * (2) within records that overlap the start position
+   * (3) occur at the start position
+   * (4) beyond the start position
+   *
+   * Test should confirm that all records are returned only once upon successful completion of the retried stream.
+   */
+  
 }


### PR DESCRIPTION
The current variants and reads integration tests pass.  Next step is to add additional tests for the retries before this can be merged to master.

Note that in all cases it currently creates a new iterator (sends a new Streaming request) upon retry.  It does not currently re-create the stub or the channel for certain status codes.  Those specific changes can be made if certain status codes correspond to failures that require more mitigation.