### PR TITLE
Added tests for gRPC retries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,12 @@
       <artifactId>grpc-all</artifactId>
       <version>0.9.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-interop-testing</artifactId>
+      <version>0.9.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Used to test the custom builder logic -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,12 +140,6 @@
       <artifactId>grpc-all</artifactId>
       <version>0.9.0</version>
     </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-interop-testing</artifactId>
-      <version>0.9.0</version>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Used to test the custom builder logic -->
     <dependency>

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/Example.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/Example.java
@@ -1,5 +1,7 @@
 package com.google.cloud.genomics.utils.grpc;
 
+import io.grpc.ManagedChannel;
+
 import java.io.FileNotFoundException;
 import java.util.Iterator;
 
@@ -34,7 +36,7 @@ public class Example {
       return;
     }
     
-    GenomicsChannel channel = GenomicsChannel.fromOfflineAuth(auth);
+    ManagedChannel channel = GenomicsChannel.fromOfflineAuth(auth);
 
     // Regular RPC example: list all reference set assembly ids.
     ReferenceServiceV1BlockingStub refStub =

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsChannel.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsChannel.java
@@ -13,13 +13,9 @@
  */
 package com.google.cloud.genomics.utils.grpc;
 
-import io.grpc.CallOptions;
-import io.grpc.Channel;
-import io.grpc.ClientCall;
-import io.grpc.ClientInterceptors;
+import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
-import io.grpc.MethodDescriptor;
 import io.grpc.auth.ClientAuthInterceptor;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
@@ -30,9 +26,9 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLException;
 
@@ -42,19 +38,15 @@ import com.google.cloud.genomics.utils.GenomicsFactory;
 /**
  * A convenience class for creating gRPC channels to the Google Genomics API.
  */
-public class GenomicsChannel extends ManagedChannel {
+public class GenomicsChannel {
   private static final String GENOMICS_ENDPOINT = "genomics.googleapis.com";
   private static final String GENOMICS_SCOPE = "https://www.googleapis.com/auth/genomics";
   private static final String API_KEY_HEADER = "X-Goog-Api-Key";
   // TODO https://github.com/googlegenomics/utils-java/issues/48
   private static final String PARTIAL_RESPONSE_HEADER = "X-Goog-FieldMask";
 
-  // NOTE: Unfortunately we need to keep a handle to both of these since Channel does not expose
-  // the shutdown method and the ClientInterceptors do not return the ManagedChannel instance.
-  private final ManagedChannel managedChannel;
-  private final Channel delegate;
-
-  private ManagedChannel getGenomicsManagedChannel() throws SSLException {
+  private static ManagedChannel getGenomicsManagedChannel(List<ClientInterceptor> interceptors)
+      throws SSLException {
     // Java 8's implementation of GCM ciphers is extremely slow. Therefore we disable
     // them here.
     List<String> defaultCiphers = GrpcSslContexts.forClient().ciphers(null).build().cipherSuites();
@@ -67,110 +59,68 @@ public class GenomicsChannel extends ManagedChannel {
 
     return NettyChannelBuilder.forAddress(GENOMICS_ENDPOINT, 443)
         .negotiationType(NegotiationType.TLS)
-        .sslContext(GrpcSslContexts.forClient().ciphers(performantCiphers).build()).build();
+        .sslContext(GrpcSslContexts.forClient().ciphers(performantCiphers).build())
+        .intercept(interceptors).build();
   }
 
-  private GenomicsChannel(String apiKey) throws SSLException {
-    managedChannel = getGenomicsManagedChannel();
+  /**
+   * Create a new gRPC channel to the Google Genomics API, using the provided api key for auth.
+   *
+   * @param apiKey the api key
+   * @return the ManagedChannel
+   * @throws SSLException
+   */
+  public static ManagedChannel fromApiKey(String apiKey) throws SSLException {
     Metadata headers = new Metadata();
     Metadata.Key<String> apiKeyHeader =
         Metadata.Key.of(API_KEY_HEADER, Metadata.ASCII_STRING_MARSHALLER);
     headers.put(apiKeyHeader, apiKey);
-    delegate =
-        ClientInterceptors.intercept(managedChannel,
-            MetadataUtils.newAttachHeadersInterceptor(headers));
-  }
-
-  private GenomicsChannel(GoogleCredentials creds) throws SSLException {
-    managedChannel = getGenomicsManagedChannel();
-    creds = creds.createScoped(Arrays.asList(GENOMICS_SCOPE));
-    ClientAuthInterceptor interceptor =
-        new ClientAuthInterceptor(creds, Executors.newSingleThreadExecutor());
-    delegate = ClientInterceptors.intercept(managedChannel, interceptor);
-  }
-
-  @Override
-  public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
-      MethodDescriptor<RequestT, ResponseT> arg0, CallOptions arg1) {
-    return delegate.newCall(arg0, arg1);
+    // TODO https://github.com/googlegenomics/utils-java/issues/48
+    return getGenomicsManagedChannel(Collections.singletonList(MetadataUtils
+        .newAttachHeadersInterceptor(headers)));
   }
 
   /**
-   * @throws InterruptedException
-   * @see io.grpc.ManagedChannel#shutdown()
-   * @see io.grpc.ManagedChannel#awaitTermination(long, TimeUnit)
+   * Create a new gRPC channel to the Google Genomics API, using the provided credentials for auth.
+   *
+   * @param creds the credential
+   * @return the ManagedChannel
+   * @throws SSLException
    */
-  public void shutdown(long timeout, TimeUnit unit) throws InterruptedException {
-    managedChannel.shutdown().awaitTermination(timeout, unit);
-  }
-
-
-  @Override
-  public boolean awaitTermination(long time, TimeUnit unit) throws InterruptedException {
-    return managedChannel.awaitTermination(time, unit);
-  }
-
-  @Override
-  public boolean isShutdown() {
-    return managedChannel.isShutdown();
-  }
-
-  @Override
-  public boolean isTerminated() {
-    return managedChannel.isTerminated();
-  }
-
-  @Override
-  public ManagedChannel shutdown() {
-    return managedChannel.shutdown();
-  }
-
-  @Override
-  public ManagedChannel shutdownNow() {
-    return managedChannel.shutdownNow();
-  }
-
-  @Override
-  public String authority() {
-    return managedChannel.authority();
+  public static ManagedChannel fromCreds(GoogleCredentials creds) throws SSLException {
+    ClientInterceptor interceptor =
+        new ClientAuthInterceptor(creds.createScoped(Arrays.asList(GENOMICS_SCOPE)),
+            Executors.newSingleThreadExecutor());
+    // TODO https://github.com/googlegenomics/utils-java/issues/48
+    return getGenomicsManagedChannel(Collections.singletonList(interceptor));
   }
 
   /**
-   * Creates a new gRPC channel to the Google Genomics API, using the application default
-   * credentials for auth.
+   * Create a new gRPC channel to the Google Genomics API, using the application default credentials
+   * for auth.
+   *
+   * @return the ManagedChannel
+   * @throws SSLException
+   * @throws IOException
    */
-  public static GenomicsChannel fromDefaultCreds() throws IOException {
+  public static ManagedChannel fromDefaultCreds() throws SSLException, IOException {
     return fromCreds(GoogleCredentials.getApplicationDefault());
   }
 
   /**
-   * Creates a new gRPC channel to the Google Genomics API, using the provided api key for auth.
-   */
-  public static GenomicsChannel fromApiKey(String apiKey) throws SSLException {
-    return new GenomicsChannel(apiKey);
-  }
-
-  /**
-   * Creates a new gRPC channel to the Google Genomics API, using the provided credentials for auth.
-   */
-  public static GenomicsChannel fromCreds(GoogleCredentials creds) throws IOException {
-    return new GenomicsChannel(creds);
-  }
-
-  /**
-   * Initialize auth for a gRPC channel from OfflineAuth or the application default credentials.
+   * Create a new gRPC channel to the Google Genomics API, using OfflineAuth or the application
+   * default credentials.
    * 
    * This library works with both the older and newer support for OAuth2 clients.
    * 
    * https://developers.google.com/identity/protocols/application-default-credentials
    * 
-   * @param auth An OfflineAuth object.
-   * @return The gRPC channel authorized using either the information in the OfflineAuth or
-   *         application default credentials.
+   * @param auth the OfflineAuth object
+   * @return the ManagedChannel
    * @throws IOException
    * @throws GeneralSecurityException
    */
-  public static GenomicsChannel fromOfflineAuth(GenomicsFactory.OfflineAuth auth)
+  public static ManagedChannel fromOfflineAuth(GenomicsFactory.OfflineAuth auth)
       throws IOException, GeneralSecurityException {
     if (auth.hasUserCredentials()) {
       return fromCreds(auth.getUserCredentials());

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
@@ -168,6 +168,7 @@ public abstract class GenomicsStreamIterator<Request, Response, Item, Stub exten
       // We have never returned any data. No need to set up state needed to filter previously
       // returned results.
       delegate = createIterator(originalRequest);
+      return;
     }
 
     if (getRequestStart(originalRequest) < getDataItemStart(lastSuccessfulDataItem)) {

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
@@ -59,8 +59,8 @@ public abstract class GenomicsStreamIterator<Request, Response, Item, Stub exten
   /**
    * Create a stream iterator that will filter shard data using the predicate, if supplied.
    * 
+   * @param channel The channel.
    * @param request The request for the shard of data.
-   * @param auth The OfflineAuth to use for the request.
    * @param fields Which fields to include in a partial response or null for all. NOT YET
    *        IMPLEMENTED.
    * @param shardPredicate A predicate used to client-side filter results returned (e.g., enforce a

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIterator.java
@@ -13,8 +13,9 @@
  */
 package com.google.cloud.genomics.utils.grpc;
 
+import io.grpc.ManagedChannel;
+
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
@@ -22,7 +23,6 @@ import java.util.logging.Logger;
 
 import com.google.api.client.util.BackOff;
 import com.google.api.client.util.ExponentialBackOff;
-import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -33,7 +33,7 @@ import com.google.common.collect.Lists;
  * Includes complex retry logic to upon failure resume the stream at the last known good start
  * position without returning duplicate data.
  * 
- * TODO: refactor this further to simplify the generic signature. 
+ * TODO: refactor this further to simplify the generic signature.
  * 
  * @param <Request> Streaming request type.
  * @param <Response> Streaming response type.
@@ -43,11 +43,13 @@ import com.google.common.collect.Lists;
 public abstract class GenomicsStreamIterator<Request, Response, Item, Stub extends io.grpc.stub.AbstractStub<Stub>>
     implements Iterator<Response> {
   private static final Logger LOG = Logger.getLogger(GenomicsStreamIterator.class.getName());
-  private final ExponentialBackOff backoff;
-  private final GenomicsChannel genomicsChannel;
-  private final Predicate<Item> shardPredicate;
+
+  protected final ManagedChannel genomicsChannel;
+  protected final Predicate<Item> shardPredicate;
   protected final Stub stub;
   protected final Request originalRequest;
+
+  protected ExponentialBackOff backoff;
 
   // Stateful members used to facilitate complex retry behavior for gRPC streams.
   private Iterator<Response> delegate;
@@ -61,16 +63,15 @@ public abstract class GenomicsStreamIterator<Request, Response, Item, Stub exten
    * @param auth The OfflineAuth to use for the request.
    * @param fields Which fields to include in a partial response or null for all. NOT YET
    *        IMPLEMENTED.
-   * @param shardPredicate A predicate used to client-side filter results returned (e.g., enforce
-   *             a shard boundary and/or limit to SNPs only) or null for no filtering.
-   * @throws IOException
-   * @throws GeneralSecurityException
+   * @param shardPredicate A predicate used to client-side filter results returned (e.g., enforce a
+   *        shard boundary and/or limit to SNPs only) or null for no filtering.
    */
-  public GenomicsStreamIterator(Request request, GenomicsFactory.OfflineAuth auth, String fields,
-      Predicate<Item> shardPredicate) throws IOException, GeneralSecurityException {
+
+  protected GenomicsStreamIterator(ManagedChannel channel, Request request, String fields,
+      Predicate<Item> shardPredicate) {
     this.originalRequest = request;
     this.shardPredicate = shardPredicate;
-    genomicsChannel = GenomicsChannel.fromOfflineAuth(auth);
+    this.genomicsChannel = channel;
     stub = createStub(genomicsChannel);
 
     // Using default backoff settings. For details, see
@@ -83,7 +84,7 @@ public abstract class GenomicsStreamIterator<Request, Response, Item, Stub exten
     idSentinel = null;
   }
 
-  abstract Stub createStub(GenomicsChannel genomicsChannel);
+  abstract Stub createStub(ManagedChannel genomicsChannel);
 
   abstract Iterator<Response> createIteratorFromStub(Request request);
 

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 import com.google.api.services.genomics.model.ReferenceBound;
-import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
 import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
 
 /**
@@ -71,6 +70,7 @@ public class IntegrationTestHelper {
   };
   public static final String PLATINUM_GENOMES_REFERENCE_SET_ID = "CNfS6aHAoved2AEQ6PnzkOzw15rqAQ";
   public static final String PLATINUM_GENOMES_BRCA1_REFERENCES = "chr17:41196311:41277499";
+  public static final int PLATINUM_GENOMES_BRCA1_EXPECTED_NUM_VARIANTS = 19517;
   public static final String PLATINUM_GENOMES_KLOTHO_REFERENCES = "chr13:33628137:33628138";
   public static final ReferenceBound[] PLATINUM_GENOMES_VARIANTSET_BOUNDS = {
     new ReferenceBound().setReferenceName("chr1").setUpperBound(250226910L),

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.genomics.utils.grpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.integration.AbstractTransportTest;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Random;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.genomics.utils.IntegrationTestHelper;
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.genomics.v1.StreamVariantsRequest;
+import com.google.genomics.v1.StreamVariantsResponse;
+import com.google.genomics.v1.StreamingVariantServiceGrpc;
+
+@RunWith(JUnit4.class)
+public class FaultyGenomicsServerITCase extends AbstractTransportTest {
+  private static String serverName = "integrationTest";
+  
+  static IntegrationTestHelper helper;
+  static GenomicsChannel genomicsChannel;
+  static double faultPercentage = 0.0;
+
+  /**
+   * Starts the in-process server that calls the real service.
+   * 
+   * @throws GeneralSecurityException
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void startServer() throws IOException, GeneralSecurityException {
+    startStaticServer(InProcessServerBuilder.forName(serverName)
+        .addService(StreamingVariantServiceGrpc.bindService(new VariantsIntegrationServerImpl())));
+    helper = new IntegrationTestHelper();
+    genomicsChannel = GenomicsChannel.fromOfflineAuth(helper.getAuth());
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    stopStaticServer();
+  }
+
+  @Override
+  protected ManagedChannel createChannel() {
+    return InProcessChannelBuilder.forName(serverName).build();
+  }
+
+  static class VariantsIntegrationServerImpl implements
+      StreamingVariantServiceGrpc.StreamingVariantService {
+    final Random random = new Random();
+
+    @Override
+    public void streamVariants(StreamVariantsRequest request,
+        final StreamObserver<StreamVariantsResponse> responseObserver) {
+
+      StreamingVariantServiceGrpc.newStub(genomicsChannel).streamVariants(request,
+          new StreamObserver<StreamVariantsResponse>() {
+            private boolean injectedError;
+            
+            @Override
+            public void onNext(StreamVariantsResponse response) {
+              if (injectedError) {
+                return;
+              }
+              double rand = random.nextDouble();
+              if (faultPercentage > rand) {
+                responseObserver.onError(Status.UNAVAILABLE.withDescription("injected fault")
+                    .asRuntimeException());
+                injectedError = true;
+                // TODO: this works to cancel the call, but investigate other options
+                throw new RuntimeException("cancel the call");
+              }
+              responseObserver.onNext(response);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+              if (injectedError) {
+                return;
+              }
+              responseObserver.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+              if (injectedError) {
+                return;
+              }
+              responseObserver.onCompleted();
+            }
+          });
+    }
+  }
+  
+  void runRetryTest(final GenomicsStreamIterator iter, double faultPercentage, int expectedNumItems) {
+    FaultyGenomicsServerITCase.faultPercentage = faultPercentage;
+    TestHelper.consumeStreamTest(iter, expectedNumItems);
+  }
+  
+  @Test
+  public void testVariantRetries() {
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+            helper.PLATINUM_GENOMES_BRCA1_REFERENCES, 1000000000L);
+    VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    // Dev Note: this data currently comes back as 20 separate lists but this is controlled server-side.
+    // We're using a pretty high fault rate here (25%) to ensure we see a few faults during each test run.
+    runRetryTest(iter, 0.25, helper.PLATINUM_GENOMES_BRCA1_EXPECTED_NUM_VARIANTS);
+  }
+  
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
@@ -46,7 +46,9 @@ public class FaultyGenomicsServerITCase {
   protected static Server server;
   protected static IntegrationTestHelper helper;
   protected static GenomicsChannel genomicsChannel;
-  protected static double faultPercentage = 0.0;
+  
+  // Variable accessed by both the InProcess Server executor threads and the test thread.
+  protected static volatile double faultPercentage = 0.0;
 
   /**
    * Starts the in-process server that calls the real service.

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
@@ -45,7 +45,7 @@ public class FaultyGenomicsServerITCase {
   
   protected static Server server;
   protected static IntegrationTestHelper helper;
-  protected static GenomicsChannel genomicsChannel;
+  protected static ManagedChannel genomicsChannel;
   
   // Variable accessed by both the InProcess Server executor threads and the test thread.
   protected static volatile double faultPercentage = 0.0;

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils.grpc;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+import org.junit.Test;
+
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.genomics.v1.StreamVariantsRequest;
+
+/**
+ * This is a long-running test (~20 minutes) and will not be run by either surefire or failsafe by
+ * default.
+ * 
+ * To run it: mvn -Dit.test=FaultyGenomicsServerITLongCase verify
+ *
+ */
+public class FaultyGenomicsServerITLongCase extends FaultyGenomicsServerITCase {
+
+  // Create one long stream.
+  ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(
+      helper.PLATINUM_GENOMES_VARIANTSET, "chrY:0:60032946", 1000000000L);
+  final int EXPECTED_CHRY_NUM_VARIANTS = 5971309;
+
+  @Test
+  public void testOnePercentVariantFaults() throws IOException, GeneralSecurityException {
+    VariantStreamIterator iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
+            ShardBoundary.Requirement.STRICT, null);
+    runRetryTest(iter, 0.01, EXPECTED_CHRY_NUM_VARIANTS);
+  }
+
+  @Test
+  public void testFivePercentVariantFaults() throws IOException, GeneralSecurityException {
+    VariantStreamIterator iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
+            ShardBoundary.Requirement.STRICT, null);
+    runRetryTest(iter, 0.05, EXPECTED_CHRY_NUM_VARIANTS);
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
@@ -33,9 +33,9 @@ import com.google.genomics.v1.StreamVariantsRequest;
 public class FaultyGenomicsServerITLongCase extends FaultyGenomicsServerITCase {
 
   // Create one long stream.
-  ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(
+  private static final ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(
       helper.PLATINUM_GENOMES_VARIANTSET, "chrY:0:60032946", 1000000000L);
-  final int EXPECTED_CHRY_NUM_VARIANTS = 5971309;
+  private static final int EXPECTED_CHRY_NUM_VARIANTS = 5971309;
 
   @Test
   public void testOnePercentVariantFaults() throws IOException, GeneralSecurityException {

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorRetryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorRetryTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.genomics.utils.grpc;
+
+import static org.junit.Assert.assertEquals;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.integration.AbstractTransportTest;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamReadsResponse;
+import com.google.genomics.v1.StreamVariantsRequest;
+import com.google.genomics.v1.StreamVariantsResponse;
+import com.google.genomics.v1.StreamingReadServiceGrpc;
+import com.google.genomics.v1.StreamingVariantServiceGrpc;
+import com.google.protobuf.Message;
+
+/**
+ * Retry tests for reads and variants.
+ * 
+ * Test retries that occur at: 
+ * 
+ *  (1) the beginning of the stream
+ *  (2) within records that overlap the start position 
+ *  (3) occur at the start position 
+ *  (4) beyond the start position
+ *
+ * Test should confirm that all records are returned only once upon successful completion of the
+ * retried stream.
+ */
+@RunWith(JUnit4.class)
+public class GenomicsStreamIteratorRetryTest extends AbstractTransportTest {
+  private static String serverName = "unitTest";
+
+  final static StreamReadsResponse[] READ_RESPONSES = {
+    StreamReadsResponse.newBuilder()
+    .addAlignments(TestHelper.makeRead(400, 505))
+    .addAlignments(TestHelper.makeRead(400, 510))
+    .addAlignments(TestHelper.makeRead(450, 600)).build(),
+    StreamReadsResponse.newBuilder()
+    .addAlignments(TestHelper.makeRead(450, 610))
+    .addAlignments(TestHelper.makeRead(500, 505))
+    .addAlignments(TestHelper.makeRead(505, 511)).build(),
+    StreamReadsResponse.newBuilder()
+    .addAlignments(TestHelper.makeRead(505, 700))
+    .addAlignments(TestHelper.makeRead(511, 555))
+    .addAlignments(TestHelper.makeRead(511, 556)).build()
+  };
+  
+  final static StreamVariantsResponse[] VARIANT_RESPONSES = {
+    StreamVariantsResponse.newBuilder()
+    .addVariants(TestHelper.makeVariant(400, 505))
+    .addVariants(TestHelper.makeVariant(400, 510))
+    .addVariants(TestHelper.makeVariant(450, 600)).build(),
+    StreamVariantsResponse.newBuilder()
+    .addVariants(TestHelper.makeVariant(450, 610))
+    .addVariants(TestHelper.makeVariant(500, 505))
+    .addVariants(TestHelper.makeVariant(505, 511)).build(),
+    StreamVariantsResponse.newBuilder()
+    .addVariants(TestHelper.makeVariant(505, 700))
+    .addVariants(TestHelper.makeVariant(511, 555))
+    .addVariants(TestHelper.makeVariant(511, 556)).build()
+  };
+  
+  final static long REQUEST_START_POSITION = 450;
+  final static StreamReadsRequest READS_REQUEST = StreamReadsRequest.newBuilder()
+      .setStart(REQUEST_START_POSITION).build();
+  final static StreamVariantsRequest VARIANTS_REQUEST = StreamVariantsRequest.newBuilder()
+      .setStart(REQUEST_START_POSITION).build();
+  
+  enum InjectionSite {
+    AT_BEGINNING, AFTER_FIRST_RESPONSE, AFTER_SECOND_RESPONSE, AT_END
+  };
+  static InjectionSite injectionSite;
+  static boolean failNow;
+  static long lastObservedRequestStartPosition;
+
+  /**
+   * Starts the in-process server.
+   */
+  @BeforeClass
+  public static void startServer() {
+    startStaticServer(InProcessServerBuilder.forName(serverName)
+        .addService(StreamingReadServiceGrpc.bindService(new UnitServerImpl()))
+        .addService(StreamingVariantServiceGrpc.bindService(new UnitServerImpl())));
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    stopStaticServer();
+  }
+
+  @Override
+  protected ManagedChannel createChannel() {
+    return InProcessChannelBuilder.forName(serverName).build();
+  }
+
+  private static class UnitServerImpl implements
+  StreamingReadServiceGrpc.StreamingReadService,
+      StreamingVariantServiceGrpc.StreamingVariantService {
+    
+    @Override
+    public void streamReads(StreamReadsRequest request,
+        StreamObserver<StreamReadsResponse> responseObserver) {
+      // Set this to later confirm that the request start position is updated
+      // for retrying data beyond the start position.
+      lastObservedRequestStartPosition = request.getStart();
+      respondWithFaults(responseObserver, READ_RESPONSES);
+    }
+
+    @Override
+    public void streamVariants(StreamVariantsRequest request,
+        StreamObserver<StreamVariantsResponse> responseObserver) {
+      // Set this to later confirm that the request start position is updated
+      // for retrying data beyond the start position.
+      lastObservedRequestStartPosition = request.getStart();
+      respondWithFaults(responseObserver, VARIANT_RESPONSES);
+    }
+
+    private void respondWithFaults(StreamObserver responseObserver, Message[] responses) {
+      if (failNow && InjectionSite.AT_BEGINNING.equals(injectionSite)) {
+        failNow = !failNow;
+        responseObserver.onError(Status.UNAVAILABLE.withDescription("injected fault")
+            .asRuntimeException());
+        return;
+      } else {
+        responseObserver.onNext(responses[0]);
+      }
+
+      if (failNow && InjectionSite.AFTER_FIRST_RESPONSE.equals(injectionSite)) {
+        failNow = !failNow;
+        responseObserver.onError(Status.UNAVAILABLE.withDescription("injected fault")
+            .asRuntimeException());
+        return;
+      } else {
+        responseObserver.onNext(responses[1]);
+      }
+
+      if (failNow && InjectionSite.AFTER_SECOND_RESPONSE.equals(injectionSite)) {
+        failNow = !failNow;
+        responseObserver.onError(Status.UNAVAILABLE.withDescription("injected fault")
+            .asRuntimeException());
+        return;
+      } else {
+        responseObserver.onNext(responses[2]);
+      }
+
+      if (failNow && InjectionSite.AT_END.equals(injectionSite)) {
+        failNow = !failNow;
+        responseObserver.onError(Status.UNAVAILABLE.withDescription("injected fault")
+            .asRuntimeException());
+        return;
+      } else {
+        responseObserver.onCompleted();
+      }
+    }
+  }
+
+  void runTest(final GenomicsStreamIterator iter, InjectionSite site, int expectedNumItems) {
+    injectionSite = site;
+    failNow = true;
+    
+    TestHelper.consumeStreamTest(iter, expectedNumItems);
+    
+    if (InjectionSite.AFTER_SECOND_RESPONSE.equals(injectionSite)) {
+      assertEquals(505L, lastObservedRequestStartPosition);
+    } else if (InjectionSite.AT_END.equals(injectionSite)) {
+      assertEquals(511L, lastObservedRequestStartPosition);
+    } else {
+      assertEquals(REQUEST_START_POSITION, lastObservedRequestStartPosition);
+    }
+  }
+  
+  // The following tests could be collapsed into a for loop upon the injection site enumeration,
+  // but breaking them out separately makes it easier to understand failures if they happen.
+
+  @Test
+  public void testRetriesAfterFirstResponse() {
+    InjectionSite site = InjectionSite.AFTER_FIRST_RESPONSE;
+    GenomicsStreamIterator iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+  }
+
+  @Test
+  public void testRetriesAfterSecondResponse() {
+    InjectionSite site = InjectionSite.AFTER_SECOND_RESPONSE;
+    GenomicsStreamIterator iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+  }
+
+  @Test
+  public void testRetriesAtBeginning() {
+    InjectionSite site = InjectionSite.AT_BEGINNING;
+    GenomicsStreamIterator iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+  }
+
+  @Test
+  public void testRetriesAtEnd() {
+    InjectionSite site = InjectionSite.AT_END;
+    GenomicsStreamIterator iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+    
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.STRICT, null);
+    runTest(iter, site, 7);
+
+    iter =
+        ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
+            ShardBoundary.Requirement.OVERLAPS, null);
+    runTest(iter, site, 9);
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorRetryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorRetryTest.java
@@ -86,10 +86,12 @@ public class GenomicsStreamIteratorRetryTest {
     AT_BEGINNING, AFTER_FIRST_RESPONSE, AFTER_SECOND_RESPONSE, AT_END
   };
 
-  protected static InjectionSite injectionSite;
-  protected static boolean failNow;
-  protected static long lastObservedRequestStartPosition;
   protected static Server server;
+
+  // Variables accessed by both the InProcess Server executor threads and the test thread.
+  protected static volatile InjectionSite injectionSite;
+  protected static volatile boolean failNow;
+  protected static volatile long lastObservedRequestStartPosition;
 
   /**
    * Starts the in-process server.

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorRetryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorRetryTest.java
@@ -43,12 +43,12 @@ import com.google.protobuf.Message;
 /**
  * Retry tests for reads and variants.
  * 
- * Test retries that occur at: 
+ * Test retries that occur at:
  * 
- *  (1) the beginning of the stream
- *  (2) within records that overlap the start position 
- *  (3) occur at the start position 
- *  (4) beyond the start position
+ * (1) the beginning of the stream
+ * (2) within records that overlap the start position
+ * (3) occur at the start position
+ * (4) beyond the start position
  *
  * Test should confirm that all records are returned only once upon successful completion of the
  * retried stream.
@@ -57,39 +57,31 @@ import com.google.protobuf.Message;
 public class GenomicsStreamIteratorRetryTest {
   public static final String SERVER_NAME = "unitTest";
   public static final StreamReadsResponse[] READ_RESPONSES = {
-    StreamReadsResponse.newBuilder()
-    .addAlignments(TestHelper.makeRead(400, 505))
-    .addAlignments(TestHelper.makeRead(400, 510))
-    .addAlignments(TestHelper.makeRead(450, 600)).build(),
-    StreamReadsResponse.newBuilder()
-    .addAlignments(TestHelper.makeRead(450, 610))
-    .addAlignments(TestHelper.makeRead(500, 505))
-    .addAlignments(TestHelper.makeRead(505, 511)).build(),
-    StreamReadsResponse.newBuilder()
-    .addAlignments(TestHelper.makeRead(505, 700))
-    .addAlignments(TestHelper.makeRead(511, 555))
-    .addAlignments(TestHelper.makeRead(511, 556)).build()
-  };
+      StreamReadsResponse.newBuilder().addAlignments(TestHelper.makeRead(400, 505))
+          .addAlignments(TestHelper.makeRead(400, 510))
+          .addAlignments(TestHelper.makeRead(450, 600)).build(),
+      StreamReadsResponse.newBuilder().addAlignments(TestHelper.makeRead(450, 610))
+          .addAlignments(TestHelper.makeRead(500, 505))
+          .addAlignments(TestHelper.makeRead(505, 511)).build(),
+      StreamReadsResponse.newBuilder().addAlignments(TestHelper.makeRead(505, 700))
+          .addAlignments(TestHelper.makeRead(511, 555))
+          .addAlignments(TestHelper.makeRead(511, 556)).build()};
   public static final StreamVariantsResponse[] VARIANT_RESPONSES = {
-    StreamVariantsResponse.newBuilder()
-    .addVariants(TestHelper.makeVariant(400, 505))
-    .addVariants(TestHelper.makeVariant(400, 510))
-    .addVariants(TestHelper.makeVariant(450, 600)).build(),
-    StreamVariantsResponse.newBuilder()
-    .addVariants(TestHelper.makeVariant(450, 610))
-    .addVariants(TestHelper.makeVariant(500, 505))
-    .addVariants(TestHelper.makeVariant(505, 511)).build(),
-    StreamVariantsResponse.newBuilder()
-    .addVariants(TestHelper.makeVariant(505, 700))
-    .addVariants(TestHelper.makeVariant(511, 555))
-    .addVariants(TestHelper.makeVariant(511, 556)).build()
-  };
+      StreamVariantsResponse.newBuilder().addVariants(TestHelper.makeVariant(400, 505))
+          .addVariants(TestHelper.makeVariant(400, 510))
+          .addVariants(TestHelper.makeVariant(450, 600)).build(),
+      StreamVariantsResponse.newBuilder().addVariants(TestHelper.makeVariant(450, 610))
+          .addVariants(TestHelper.makeVariant(500, 505))
+          .addVariants(TestHelper.makeVariant(505, 511)).build(),
+      StreamVariantsResponse.newBuilder().addVariants(TestHelper.makeVariant(505, 700))
+          .addVariants(TestHelper.makeVariant(511, 555))
+          .addVariants(TestHelper.makeVariant(511, 556)).build()};
   public static final long REQUEST_START_POSITION = 450;
   public static final StreamReadsRequest READS_REQUEST = StreamReadsRequest.newBuilder()
       .setStart(REQUEST_START_POSITION).build();
   public static final StreamVariantsRequest VARIANTS_REQUEST = StreamVariantsRequest.newBuilder()
       .setStart(REQUEST_START_POSITION).build();
-  
+
   enum InjectionSite {
     AT_BEGINNING, AFTER_FIRST_RESPONSE, AFTER_SECOND_RESPONSE, AT_END
   };
@@ -98,17 +90,18 @@ public class GenomicsStreamIteratorRetryTest {
   protected static boolean failNow;
   protected static long lastObservedRequestStartPosition;
   protected static Server server;
-  
+
   /**
-   * Starts the in-process server. 
+   * Starts the in-process server.
    */
   @BeforeClass
   public static void startServer() {
     try {
-      server = InProcessServerBuilder.forName(SERVER_NAME)
-          .addService(StreamingReadServiceGrpc.bindService(new UnitServerImpl()))
-          .addService(StreamingVariantServiceGrpc.bindService(new UnitServerImpl()))
-          .build().start();
+      server =
+          InProcessServerBuilder.forName(SERVER_NAME)
+              .addService(StreamingReadServiceGrpc.bindService(new UnitServerImpl()))
+              .addService(StreamingVariantServiceGrpc.bindService(new UnitServerImpl())).build()
+              .start();
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
@@ -118,11 +111,10 @@ public class GenomicsStreamIteratorRetryTest {
   public static void stopServer() {
     server.shutdownNow();
   }
-  
-  protected static class UnitServerImpl implements
-  StreamingReadServiceGrpc.StreamingReadService,
+
+  protected static class UnitServerImpl implements StreamingReadServiceGrpc.StreamingReadService,
       StreamingVariantServiceGrpc.StreamingVariantService {
-    
+
     @Override
     public void streamReads(StreamReadsRequest request,
         StreamObserver<StreamReadsResponse> responseObserver) {
@@ -187,9 +179,9 @@ public class GenomicsStreamIteratorRetryTest {
   public void runTest(final GenomicsStreamIterator iter, InjectionSite site, int expectedNumItems) {
     injectionSite = site;
     failNow = true;
-    
+
     TestHelper.consumeStreamTest(iter, expectedNumItems);
-    
+
     if (InjectionSite.AFTER_SECOND_RESPONSE.equals(injectionSite)) {
       assertEquals(505L, lastObservedRequestStartPosition);
     } else if (InjectionSite.AT_END.equals(injectionSite)) {
@@ -198,7 +190,7 @@ public class GenomicsStreamIteratorRetryTest {
       assertEquals(REQUEST_START_POSITION, lastObservedRequestStartPosition);
     }
   }
-  
+
   // The following tests could be collapsed into a for loop upon the injection site enumeration,
   // but breaking them out separately makes it easier to understand failures if they happen.
 
@@ -286,7 +278,7 @@ public class GenomicsStreamIteratorRetryTest {
         VariantStreamIterator.enforceShardBoundary(createChannel(), VARIANTS_REQUEST,
             ShardBoundary.Requirement.OVERLAPS, null);
     runTest(iter, site, 9);
-    
+
     iter =
         ReadStreamIterator.enforceShardBoundary(createChannel(), READS_REQUEST,
             ShardBoundary.Requirement.STRICT, null);

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.genomics.utils.grpc;
+
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.grpc.testing.integration.AbstractTransportTest;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.cloud.genomics.utils.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamReadsResponse;
+import com.google.genomics.v1.StreamVariantsRequest;
+import com.google.genomics.v1.StreamVariantsResponse;
+import com.google.genomics.v1.StreamingReadServiceGrpc;
+import com.google.genomics.v1.StreamingVariantServiceGrpc;
+
+@RunWith(JUnit4.class)
+public class GenomicsStreamIteratorTest extends AbstractTransportTest {
+  private static String serverName = "unitTest";
+    
+  /** Starts the in-process server. 
+   * @throws GeneralSecurityException 
+   * @throws IOException */
+  @BeforeClass
+  public static void startServer() throws IOException, GeneralSecurityException {
+    startStaticServer(InProcessServerBuilder.forName(serverName)
+        .addService(StreamingReadServiceGrpc.bindService(new ReadsUnitServerImpl()))
+        .addService(StreamingVariantServiceGrpc.bindService(new VariantsUnitServerImpl())));
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    stopStaticServer();
+  }
+
+  @Override
+  protected ManagedChannel createChannel() {
+    return InProcessChannelBuilder.forName(serverName).build();
+  }
+  
+  private static class ReadsUnitServerImpl implements StreamingReadServiceGrpc.StreamingReadService {
+    @Override
+    public void streamReads(StreamReadsRequest request,
+        StreamObserver<StreamReadsResponse> responseObserver) {
+      StreamReadsResponse response = StreamReadsResponse.newBuilder()
+          .addAlignments(TestHelper.makeRead(400, 510))
+          .addAlignments(TestHelper.makeRead(450, 505))
+          .addAlignments(TestHelper.makeRead(499, 600))
+          .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+
+  private static class VariantsUnitServerImpl implements StreamingVariantServiceGrpc.StreamingVariantService {
+    @Override
+    public void streamVariants(StreamVariantsRequest request,
+        StreamObserver<StreamVariantsResponse> responseObserver) {
+      StreamVariantsResponse response = StreamVariantsResponse.newBuilder()
+          .addVariants(TestHelper.makeVariant(400, 510))
+          .addVariants(TestHelper.makeVariant(450, 505))
+          .addVariants(TestHelper.makeVariant(499, 600))
+          .build();
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  }
+  
+  @Test
+  public void testAllReadsOverlapsStart() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamReadsRequest> requests =
+        ShardUtils.getReadRequests(Collections.singletonList("fake readgroup set"), "chr7:500:600", 1000000L);
+
+    ReadStreamIterator iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    TestHelper.consumeStreamTest(iter, 0);
+
+    iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.OVERLAPS, null);
+    TestHelper.consumeStreamTest(iter, 3);
+  }
+  
+  @Test
+  public void testAllVariantsOverlapsStart() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests("fake variant set", "chr7:500:600", 1000000L);
+
+    VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    TestHelper.consumeStreamTest(iter, 0);
+
+    iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.OVERLAPS, null);
+    TestHelper.consumeStreamTest(iter, 3);
+  }
+  
+  @Test
+  public void testSomeReadsOverlapsStart() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamReadsRequest> requests =
+        ShardUtils.getReadRequests(Collections.singletonList("fake readgroup set"), "chr7:499:600", 1000000L);
+
+    ReadStreamIterator iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    TestHelper.consumeStreamTest(iter, 1);
+
+    iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.OVERLAPS, null);
+    TestHelper.consumeStreamTest(iter, 3);
+  }
+  
+  @Test
+  public void testSomeVariantsOverlapsStart() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests("fake variant set", "chr7:499:600", 1000000L);
+
+    VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    TestHelper.consumeStreamTest(iter, 1);
+
+    iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.OVERLAPS, null);
+    TestHelper.consumeStreamTest(iter, 3);
+  }
+
+  @Test
+  public void testNoReadsOverlapsStart() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamReadsRequest> requests =
+        ShardUtils.getReadRequests(Collections.singletonList("fake readgroup set"), "chr7:300:600", 1000000L);
+
+    ReadStreamIterator iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    TestHelper.consumeStreamTest(iter, 3);
+
+    iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.OVERLAPS, null);
+    TestHelper.consumeStreamTest(iter, 3);
+  }
+  
+  @Test
+  public void testNoVariantsOverlapsStart() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests("fake variant set", "chr7:300:600", 1000000L);
+
+    VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.STRICT, null);
+    TestHelper.consumeStreamTest(iter, 3);
+
+    iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
+        ShardBoundary.Requirement.OVERLAPS, null);
+    TestHelper.consumeStreamTest(iter, 3);
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -56,7 +56,7 @@ public class ReadStreamIteratorITCase {
     assertEquals(1, requests.size());
     
     Iterator<StreamReadsResponse> iter =
-        ReadStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+        ReadStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
             ShardBoundary.Requirement.OVERLAPS, null);
     
     assertTrue(iter.hasNext());
@@ -64,8 +64,8 @@ public class ReadStreamIteratorITCase {
     assertEquals(57, readResponse.getAlignmentsList().size());
     assertFalse(iter.hasNext());
 
-    iter = ReadStreamIterator.enforceShardBoundary(requests.get(0),
-        helper.getAuth(), ShardBoundary.Requirement.STRICT, null);
+    iter = ReadStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0),
+        ShardBoundary.Requirement.STRICT, null);
     
     assertTrue(iter.hasNext());
     readResponse = iter.next();
@@ -83,7 +83,7 @@ public class ReadStreamIteratorITCase {
     assertEquals(1, requests.size());
     
     Iterator<StreamReadsResponse> iter =
-        ReadStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+        ReadStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
             ShardBoundary.Requirement.STRICT, "reads(alignments)");
     
     assertTrue(iter.hasNext());

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/TestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/TestHelper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils.grpc;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.genomics.v1.LinearAlignment;
+import com.google.genomics.v1.Position;
+import com.google.genomics.v1.Read;
+import com.google.genomics.v1.Variant;
+import com.google.protobuf.Message;
+
+public class TestHelper {
+
+  public static void consumeStreamTest(final GenomicsStreamIterator iter, int expectedNumItems) {
+    // Tweak the backoff to be static instead of exponential since we are possibly injecting
+    // fake faults.  Also note that this is used by both unit and integration tests.
+    iter.backoff =
+        new ExponentialBackOff.Builder().setInitialIntervalMillis(50).setMultiplier(1).build();
+
+    Function<Message, String> getId = new Function<Message, String>() {
+      @Override
+      public String apply(Message m) {
+        return iter.getDataItemId(m);
+      }
+    };
+
+    Set<String> uniqueReceivedIds = new HashSet<String>(expectedNumItems);
+    int numItemsReceived = 0;
+    while (iter.hasNext()) {
+      List<Message> items = iter.getDataList(iter.next());
+      numItemsReceived += items.size();
+      System.out.println("Received so far: " + numItemsReceived);
+      uniqueReceivedIds.addAll(Lists.transform(items, getId));
+    }
+    assertEquals("confirm that we received all the data we expected", expectedNumItems,
+        uniqueReceivedIds.size());
+    assertEquals("confirm that all data received is unique", uniqueReceivedIds.size(),
+        numItemsReceived);
+  }
+  
+  public static Read makeRead(long start, long end) {
+    Position position = Position.newBuilder().setPosition(start).build();
+    LinearAlignment alignment = LinearAlignment.newBuilder().setPosition(position).build();
+    return Read.newBuilder()
+        .setId(UUID.randomUUID().toString())
+        .setAlignment(alignment)
+        .setFragmentLength((int) (end - start))
+        .build();
+  }
+
+  public static Variant makeVariant(long start, long end) {
+    return Variant.newBuilder()
+        .setId(UUID.randomUUID().toString())
+        .setStart(start)
+        .setEnd(end)
+        .build();
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import com.google.cloud.genomics.utils.IntegrationTestHelper;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.genomics.v1.StreamVariantsRequest;
 import com.google.genomics.v1.StreamVariantsResponse;
@@ -39,12 +38,6 @@ import com.google.genomics.v1.Variant;
 public class VariantStreamIteratorITCase {
 
   static IntegrationTestHelper helper;
-  Function<Variant, String> getId = new Function<Variant, String>() {
-    @Override
-    public String apply(Variant v) {
-      return v.getId();
-    }
-  };
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -74,6 +74,26 @@ public class VariantStreamIteratorITCase {
   }
 
   @Test
+  public void testEmptyRegion() throws IOException, GeneralSecurityException {
+    ImmutableList<StreamVariantsRequest> requests =
+        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+            "chrDoesNotExist:100:200", 100L);
+    assertEquals(1, requests.size());
+
+    Iterator<StreamVariantsResponse> iter =
+        VariantStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.OVERLAPS, null);
+    assertFalse(iter.hasNext());
+
+    iter =
+        VariantStreamIterator.enforceShardBoundary(requests.get(0), helper.getAuth(),
+            ShardBoundary.Requirement.STRICT, null);
+    assertFalse(iter.hasNext());
+  }
+
+  // TODO test a shard where the entire first result will be empty due to the strict shard boundary requirement.  Same for reads.
+   
+  @Test
   @Ignore
   // TODO https://github.com/googlegenomics/utils-java/issues/48
   public void testPartialResponses() throws IOException, GeneralSecurityException {
@@ -98,8 +118,6 @@ public class VariantStreamIteratorITCase {
     assertNull(variants.get(0).getReferenceBases());
   }
 
-  // TODO test a shard where the entire first result will be empty due to the strict shard boundary requirement.  Same for reads.
-  
   /**
    * TODO: Retry tests.  Same for reads.
    * 


### PR DESCRIPTION
The main code changed a bit to make it easier to pass in the channel created by the [AbstractTransportTest](https://github.com/grpc/grpc-java/blob/master/interop-testing/src/test/java/io/grpc/testing/integration/InProcessTest.java) but otherwise this is mostly new tests.

Added:
* unit tests for shard boundaries (previously there were only integration tests)
* unit tests for retries
* integration tests for retries
* and a long running integration test for retries