### PR TITLE
Add V1 version of call comparator.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantUtils.java
@@ -13,13 +13,16 @@
  */
 package com.google.cloud.genomics.utils.grpc;
 
+import java.util.Comparator;
 import java.util.List;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
 import com.google.genomics.v1.Variant;
+import com.google.genomics.v1.VariantCall;
 
 public class VariantUtils {
 
@@ -93,5 +96,16 @@ public class VariantUtils {
    */
   public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT = Predicates.or(
       IS_NON_VARIANT_SEGMENT_WITH_MISSING_ALT, IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT);
+  
+  /**
+   * Comparator for sorting calls by call set name.
+   */
+  public static final Comparator<VariantCall> CALL_COMPARATOR = Ordering.natural().onResultOf(
+      new Function<VariantCall, String>() {
+        @Override
+        public String apply(VariantCall call) {
+          return call.getCallSetName();
+        }
+      });
 
 }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantUtilsTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import com.google.genomics.v1.Variant;
+import com.google.genomics.v1.VariantCall;
 
 public class VariantUtilsTest {
 
@@ -81,5 +82,20 @@ public class VariantUtilsTest {
     assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(Variant.newBuilder()
         .setReferenceName("chr7").setStart(200000).setEnd(200001).setReferenceBases("A")
         .addAlternateBases(VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT).build()));
+  }
+  
+  @Test
+  public void testCallComparator() {
+    assertTrue(0 == VariantUtils.CALL_COMPARATOR.compare(
+        VariantCall.newBuilder().setCallSetName("NA12883").build(),
+        VariantCall.newBuilder().setCallSetName("NA12883").build()));
+    
+    assertTrue(0 > VariantUtils.CALL_COMPARATOR.compare(
+        VariantCall.newBuilder().setCallSetName("NA12883").build(),
+        VariantCall.newBuilder().setCallSetName("NA12884").build()));
+
+    assertTrue(0 < VariantUtils.CALL_COMPARATOR.compare(
+        VariantCall.newBuilder().setCallSetName("NA12884").build(),
+        VariantCall.newBuilder().setCallSetName("NA12883").build()));
   }
 }


### PR DESCRIPTION
This is needed for the port of Dataflow pipeline Identity-by-State to gRPC.