### PR TITLE
Refactor Auth.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/CredentialFactory.java
+++ b/src/main/java/com/google/cloud/genomics/utils/CredentialFactory.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.extensions.java6.auth.oauth2.AbstractPromptReceiver;
+import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
+import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
+import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleOAuthConstants;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.store.FileDataStoreFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.base.Preconditions;
+
+/**
+ * Convenience routines for obtaining credentials.
+ * 
+ * For more information about auth, please see:
+ * <ul>
+ *    <li>https://developers.google.com/identity/protocols/application-default-credentials
+ *    <li>https://developers.google.com/api-client-library/java/google-oauth-java-client/oauth2
+ *    <li>https://github.com/google/google-api-java-client/tree/master/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2
+ *    <li>https://github.com/google/google-oauth-java-client
+ *    <li>https://github.com/google/google-auth-library-java
+ * </ul>
+ */
+public class CredentialFactory {
+  
+  private static final String MISSING_ADC_EXCEPTION_MESSAGE =
+      "Unable to get application default credentials. Please see "
+      + "https://developers.google.com/identity/protocols/application-default-credentials "
+      + "for details on how to specify credentials. This is dependent "
+      + "on the gcloud core component version 2015.02.05 or newer to be able "
+      + "to get credentials from the currently authorized user via gcloud auth.";
+
+  private static final List<String> SCOPES = Arrays.asList(
+      "https://www.googleapis.com/auth/cloud-platform");
+
+  private static final File CREDENTIAL_STORE = new File(
+      System.getProperty("user.home"), ".store");
+  
+  private static class PromptReceiver extends AbstractPromptReceiver {
+    @Override
+    public String getRedirectUri() {
+      return GoogleOAuthConstants.OOB_REDIRECT_URI;
+    }
+  }
+  
+  /**
+   * Obtain the Application Default com.google.api.client.auth.oauth2.Credential
+   * 
+   * @return the Application Default Credential
+   */
+  public static GoogleCredential getApplicationDefaultCredential() {
+    try {
+      return GoogleCredential.getApplicationDefault();
+    } catch (IOException e) {
+      throw new RuntimeException(MISSING_ADC_EXCEPTION_MESSAGE, e);
+    }
+  }
+  
+  /**
+   * Obtain the Application Default com.google.auth.oauth2.GoogleCredentials
+   * 
+   * This is from the newer OAuth library https://github.com/google/google-auth-library-java
+   * which is used by gRPC.
+   * 
+   * @return the Application Default Credentials
+   */
+  public static GoogleCredentials getApplicationDefaultCredentials() {
+    try {
+      return GoogleCredentials.getApplicationDefault();
+    } catch (IOException e) {
+      throw new RuntimeException(MISSING_ADC_EXCEPTION_MESSAGE, e);
+    }
+  }
+
+  /**
+   * Creates an OAuth2 credential from client secrets, which may require an interactive authorization prompt.
+   *
+   * Use this method when the Application Default Credential is not sufficient.
+   *
+   * @param clientSecretsFile The {@code client_secrets.json} file path.
+   * @param credentialId The credentialId for use in identifying the credential in the persistent credential store.
+   * @return The user credential
+   */
+  public static Credential getCredentialFromClientSecrets(String clientSecretsFile,
+      String credentialId) {
+    Preconditions.checkArgument(clientSecretsFile != null);
+    Preconditions.checkArgument(credentialId != null);
+
+    HttpTransport httpTransport;
+    try {
+      httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+    } catch (IOException | GeneralSecurityException e) {
+      throw new RuntimeException("Could not create HTTPS transport for use in credential creation", e);
+    }
+
+    JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+    GoogleClientSecrets clientSecrets;
+
+    try {
+      clientSecrets = GoogleClientSecrets.load(jsonFactory,
+          new FileReader(clientSecretsFile));
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Could not read the client secrets from file: " + clientSecretsFile,
+          e);
+    }
+
+    FileDataStoreFactory dataStoreFactory;
+    try {
+      dataStoreFactory = new FileDataStoreFactory(CREDENTIAL_STORE);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not create persisten credential store " + CREDENTIAL_STORE, e);
+    }
+
+    GoogleAuthorizationCodeFlow flow;
+    try {
+      flow = new GoogleAuthorizationCodeFlow.Builder(
+          httpTransport, jsonFactory, clientSecrets, SCOPES)
+          .setDataStoreFactory(dataStoreFactory)
+          .build();
+    } catch (IOException e) {
+      throw new RuntimeException("Could not build credential authorization flow", e);
+    }
+
+    // The credentialId identifies the credential in the persistent credential store.
+    Credential credential;
+    try {
+      credential = new AuthorizationCodeInstalledApp(flow, new PromptReceiver())
+          .authorize(credentialId);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not perform credential authorization flow", e);
+    }
+    return credential;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsFactory.java
@@ -16,11 +16,7 @@
 package com.google.cloud.genomics.utils;
 
 import java.io.File;
-import java.io.FileReader;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.Serializable;
-import java.io.StringReader;
 import java.security.GeneralSecurityException;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,11 +24,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
-import com.google.api.client.extensions.java6.auth.oauth2.VerificationCodeReceiver;
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
-import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
-import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.services.CommonGoogleClientRequestInitializer;
 import com.google.api.client.googleapis.services.GoogleClientRequestInitializer;
@@ -48,44 +39,32 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.HttpUnsuccessfulResponseHandler;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.ExponentialBackOff;
-import com.google.api.client.util.store.DataStoreFactory;
-import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.genomics.Genomics;
 import com.google.api.services.genomics.GenomicsScopes;
-import com.google.auth.oauth2.UserCredentials;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-import com.google.common.io.Files;
 
 /**
- * Code required to manufacture instances of a {@link Genomics} stub. Right now, there are 3
- * supported methods of obtaining a stub:
- *
- * <ul>
- *   <li>Using an <a href="https://developers.google.com/api-client-library/python/guide/aaa_apikeys">API key</a></li>
- *   <li>Using <a href="https://developers.google.com/api-client-library/python/guide/aaa_client_secrets">client secrets</a></li>
- *   <li>Using a <a href="https://developers.google.com/accounts/docs/OAuth2ServiceAccount">service account</a></li>
- * </ul>
+ * Code required to manufacture instances of a {@link Genomics} stub.
+ * 
+ * Several authentication mechanisms are supported.  For more detail, see
+ * https://developers.google.com/api-client-library/java/google-api-java-client/oauth2
  */
 public class GenomicsFactory {
 
   private static final int DEFAULT_CONNECT_TIMEOUT = 20000;
   private static final int DEFAULT_READ_TIMEOUT = 20000;
   private static final int DEFAULT_NUMBER_OF_RETRIES = 5;
+  private static final String DEFAULT_APPLICATION_NAME = "genomics";
   
   /**
    * A builder class for {@link GenomicsFactory} objects.
    */
   public static class Builder {
-    private static final int DATA_STORE_FACTORY_RETRIES = 3;
-
+    // TODO is application name used for anything other than the credential store path?
+    // If not, it should be removed.
     @VisibleForTesting final String applicationName;
-    @VisibleForTesting final File userDir;
-    @VisibleForTesting DataStoreFactory dataStoreFactory;
     private HttpTransport httpTransport = Utils.getDefaultTransport();
     private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
     private int readTimeout = DEFAULT_READ_TIMEOUT;
@@ -94,33 +73,9 @@ public class GenomicsFactory {
     private Optional<String> rootUrl = Optional.absent();
     private Optional<String> servicePath = Optional.absent();
     private Collection<String> scopes = GenomicsScopes.all();
-    private String userName = System.getProperty("user.name");
-    private Supplier<? extends VerificationCodeReceiver>
-        verificationCodeReceiver = Suppliers.ofInstance(new LocalServerReceiver());
 
-    Builder(String applicationName) throws IOException {
+    Builder(String applicationName) {
       this.applicationName = applicationName;
-      this.userDir = new File(
-          System.getProperty("user.home"),
-          String.format(".store/%s", applicationName.replace("/", "_")));
-
-      int retries = 0;
-      while (dataStoreFactory == null) {
-        try {
-          dataStoreFactory = makeFileDataStoreFactory();
-        } catch (IOException e) {
-          // We'll retry the creation up to three times to handle a race condition
-          // when multiple workers are on the same machine
-          retries++;
-          if (retries > DATA_STORE_FACTORY_RETRIES) {
-            throw e;
-          }
-        }
-      }
-    }
-
-    @VisibleForTesting FileDataStoreFactory makeFileDataStoreFactory() throws IOException {
-      return new FileDataStoreFactory(userDir);
     }
 
     /**
@@ -131,18 +86,14 @@ public class GenomicsFactory {
     public GenomicsFactory build() {
       return new GenomicsFactory(
           applicationName,
-          dataStoreFactory,
           httpTransport,
           connectTimeout,
           readTimeout,
           numRetries,
           jsonFactory,
           scopes,
-          userName,
           rootUrl,
-          servicePath,
-          verificationCodeReceiver,
-          userDir);
+          servicePath);
     }
 
     /**
@@ -229,31 +180,15 @@ public class GenomicsFactory {
       this.scopes = scopes;
       return this;
     }
+  }
 
-    /**
-     * Set the user name. The default is {@code System.getProperty("user.name")}. Most code will
-     * rarely have to call this method.
-     *
-     * @param userName The user name to use.
-     * @return this builder
-     */
-    public Builder setUserName(String userName) {
-      this.userName = userName;
-      return this;
-    }
-
-    /**
-     * Sets the {@link Supplier} of the {@link VerificationCodeReceiver}.
-     *
-     * @param verificationCodeReceiver The {@code Supplier} of the {@code VerificationCodeReceiver}
-     *        to use.
-     * @return this builder
-     */
-    public Builder setVerificationCodeReceiver(
-        Supplier<? extends VerificationCodeReceiver> verificationCodeReceiver) {
-      this.verificationCodeReceiver = verificationCodeReceiver;
-      return this;
-    }
+  /**
+   * Create a new {@link Builder} for {@code GenomicsFactory} objects.
+   *
+   * @return the new {@code Builder} object.
+   */
+  public static Builder builder() {
+    return new Builder(DEFAULT_APPLICATION_NAME);
   }
 
   /**
@@ -261,17 +196,13 @@ public class GenomicsFactory {
    *
    * @param applicationName The name of this application.
    * @return the new {@code Builder} object.
-   * @throws GeneralSecurityException
-   * @throws IOException
    */
-  public static Builder builder(String applicationName)
-      throws GeneralSecurityException, IOException {
+  public static Builder builder(String applicationName) {
     return new Builder(applicationName);
   }
 
   private final String applicationName;
 
-  private final DataStoreFactory dataStoreFactory;
   private final HttpTransport httpTransport;
   private final int connectTimeout;
   private final int readTimeout;
@@ -280,9 +211,6 @@ public class GenomicsFactory {
   private final Optional<String> rootUrl;
   private final Optional<String> servicePath;
   private final Collection<String> scopes;
-  private final File userDir;
-  private final String userName;
-  private final Supplier<? extends VerificationCodeReceiver> verificationCodeReceiver;
 
   private final AtomicInteger initializedRequestsCount = new AtomicInteger();
   private final AtomicInteger unsuccessfulResponsesCount = new AtomicInteger();
@@ -290,31 +218,23 @@ public class GenomicsFactory {
 
   private GenomicsFactory(
       String applicationName,
-      DataStoreFactory dataStoreFactory,
       HttpTransport httpTransport,
       int connectTimeout, 
       int readTimeout,
       int numRetries,
       JsonFactory jsonFactory,
       Collection<String> scopes,
-      String userName,
       Optional<String> rootUrl,
-      Optional<String> servicePath,
-      Supplier<? extends VerificationCodeReceiver> verificationCodeReceiver,
-      File userDir) {
+      Optional<String> servicePath) {
     this.applicationName = applicationName;
-    this.dataStoreFactory = dataStoreFactory;
     this.httpTransport = httpTransport;
     this.connectTimeout = connectTimeout; 
     this.readTimeout = readTimeout;
     this.numRetries = numRetries;
     this.jsonFactory = jsonFactory;
     this.scopes = scopes;
-    this.userName = userName;
     this.rootUrl = rootUrl;
     this.servicePath = servicePath;
-    this.verificationCodeReceiver = verificationCodeReceiver;
-    this.userDir = userDir;
   }
 
   private <T extends AbstractGoogleJsonClient.Builder> T prepareBuilder(T builder,
@@ -398,10 +318,6 @@ public class GenomicsFactory {
     return jsonFactory;
   }
 
-  public DataStoreFactory getDataStoreFactory() {
-    return dataStoreFactory;
-  }
-
   public final int initializedRequestsCount() {
     return initializedRequestsCount.get();
   }
@@ -417,10 +333,11 @@ public class GenomicsFactory {
   /**
    * Create a {@link Genomics} stub using an API key.
    *
-   * @param apiKey The API key of the Google Cloud project to charge requests to.
+   * @param apiKey The API key of the Google Cloud Platform project.
    * @return The new {@code Genomics} stub
    */
   public Genomics fromApiKey(String apiKey) {
+    Preconditions.checkNotNull(apiKey);
     return fromApiKey(getGenomicsBuilder(), apiKey).build();
   }
 
@@ -428,10 +345,12 @@ public class GenomicsFactory {
    * Prepare an AbstractGoogleJsonClient.Builder using an API key.
    *
    * @param builder The builder to be prepared.
-   * @param apiKey The API key of the Google Cloud project to charge requests to.
+   * @param apiKey The API key of the Google Cloud Platform project.
    * @return The passed in builder, for easy chaining.
    */
   public <T extends AbstractGoogleJsonClient.Builder> T fromApiKey(T builder, String apiKey) {
+    Preconditions.checkNotNull(builder);
+    Preconditions.checkNotNull(apiKey);
     return prepareBuilder(builder, null, new CommonGoogleClientRequestInitializer(apiKey));
   }
 
@@ -440,9 +359,9 @@ public class GenomicsFactory {
    *
    * @param clientSecretsJson {@code client_secrets.json} file.
    * @return The new {@code Genomics} stub
-   * @throws IOException
    */
-  public Genomics fromClientSecretsFile(File clientSecretsJson) throws IOException {
+  public Genomics fromClientSecretsFile(File clientSecretsJson) {
+    Preconditions.checkNotNull(clientSecretsJson);
     return fromClientSecretsFile(getGenomicsBuilder(), clientSecretsJson).build();
   }
 
@@ -452,11 +371,59 @@ public class GenomicsFactory {
    * @param builder The builder to be prepared.
    * @param clientSecretsJson {@code client_secrets.json} file.
    * @return The passed in builder, for easy chaining.
-   * @throws IOException
    */
   public <T extends AbstractGoogleJsonClient.Builder> T fromClientSecretsFile(T builder,
-      File clientSecretsJson) throws IOException {
-    return prepareBuilder(builder, makeCredential(clientSecretsJson), null);
+      File clientSecretsJson) {
+    Preconditions.checkNotNull(builder);
+    Preconditions.checkNotNull(clientSecretsJson);
+    return prepareBuilder(builder,
+        CredentialFactory.getCredentialFromClientSecrets(clientSecretsJson.getAbsolutePath(),
+            applicationName),
+        null);
+  }
+
+  /**
+   * Create a {@link Genomics} stub using a credential.
+   *
+   * @param credential The credential to be used for requests.
+   * @return The new {@code Genomics} stub
+   */
+  public Genomics fromCredential(Credential credential) {
+    Preconditions.checkNotNull(credential);
+    return fromCredential(getGenomicsBuilder(), credential).build();
+  }
+
+  /**
+   * Prepare an AbstractGoogleJsonClient.Builder using a credential.
+   *
+   * @param builder The builder to be prepared.
+   * @param credential The credential to be used for requests.
+   * @return The passed in builder, for easy chaining.
+   */
+  public <T extends AbstractGoogleJsonClient.Builder> T fromCredential(T builder, Credential credential) {
+    Preconditions.checkNotNull(builder);
+    Preconditions.checkNotNull(credential);
+    return prepareBuilder(builder, credential, null);
+  }
+  
+  /**
+   * Create a {@link Genomics} stub using the Application Default Credential.
+   *
+   * @return The new {@code Genomics} stub
+   */
+  public Genomics fromApplicationDefaultCredential() {
+    return fromCredential(CredentialFactory.getApplicationDefaultCredential());
+  }
+
+  /**
+   * Prepare an AbstractGoogleJsonClient.Builder using the Application Default Credential.
+   *
+   * @param builder The builder to be prepared.
+   * @return The passed in builder, for easy chaining.
+   */
+  public <T extends AbstractGoogleJsonClient.Builder> T fromApplicationDefaultCredential(T builder) {
+    Preconditions.checkNotNull(builder);
+    return fromCredential(builder, CredentialFactory.getApplicationDefaultCredential());
   }
 
   /**
@@ -470,6 +437,8 @@ public class GenomicsFactory {
    */
   public Genomics fromServiceAccount(String serviceAccountId, File p12File)
       throws GeneralSecurityException, IOException {
+    Preconditions.checkNotNull(serviceAccountId);
+    Preconditions.checkNotNull(p12File);
     return fromServiceAccount(getGenomicsBuilder(), serviceAccountId, p12File).build();
   }
 
@@ -486,229 +455,42 @@ public class GenomicsFactory {
    */
   public <T extends AbstractGoogleJsonClient.Builder> T fromServiceAccount(T builder,
       String serviceAccountId, File p12File) throws GeneralSecurityException, IOException {
-    return prepareBuilder(builder, refreshToken(
-        new GoogleCredential.Builder()
-            .setTransport(httpTransport)
-            .setJsonFactory(jsonFactory)
-            .setServiceAccountId(serviceAccountId)
-            .setServiceAccountScopes(scopes)
-            .setServiceAccountPrivateKeyFromP12File(p12File)
-            .build()), null);
+    Preconditions.checkNotNull(builder);
+    GoogleCredential creds = new GoogleCredential.Builder()
+        .setTransport(httpTransport)
+        .setJsonFactory(jsonFactory)
+        .setServiceAccountId(serviceAccountId)
+        .setServiceAccountScopes(scopes)
+        .setServiceAccountPrivateKeyFromP12File(p12File)
+        .build();
+    creds.refreshToken();
+    return prepareBuilder(builder, creds, null);
   }
-
-  private Credential makeCredential(File clientSecretsJson) throws IOException {
-    Reader in = null;
-    boolean returnNormally = true;
-    try {
-      GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow
-          .Builder(
-              httpTransport,
-              jsonFactory,
-              GoogleClientSecrets.load(jsonFactory, in = new FileReader(clientSecretsJson)),
-              scopes)
-          .setDataStoreFactory(dataStoreFactory)
-          .setAccessType("offline")
-          .setApprovalPrompt("force")
-          .build();
-      return refreshToken(
-          new AuthorizationCodeInstalledApp(flow, verificationCodeReceiver.get())
-              .authorize(userName));
-    } catch (IOException e) {
-      returnNormally = false;
-      throw e;
-    } finally {
-      if (null != in) {
-        try {
-          in.close();
-        } catch (IOException e) {
-          if (returnNormally) {
-            throw e;
-          }
-        }
-      }
-    }
-  }
-
-  private Credential refreshToken(Credential credential) throws IOException {
-    try {
-      credential.refreshToken();
-      return credential;
-    } catch (NullPointerException e) {
-      throw new IllegalStateException(
-          "Couldn't refresh the OAuth token. Are you using different client secrets? If so, you "
-              + "need to first clear the stored credentials by removing the file at "
-              + userDir.getPath() + "/StoredCredential",
-          e);
-    }
-  }
-
+  
   /**
-   * Creates offline-friendly auth object using an apiKey.
-   *
-   * Use this method when you need to store the resulting OfflineAuth for later use.
-   * Otherwise, you should create a {@link Genomics} object directly using
-   * {@code fromClientSecretsFile}.
-   *
-   * @param apiKey The API key of the Google Cloud project to charge requests to.
-   * @return An OfflineAuth object that can be passed to {@code fromOfflineAuth}
-   * @throws IOException
-   */
-  public OfflineAuth getOfflineAuthFromApiKey(String apiKey)
-      throws IOException {
-    if (apiKey == null) {
-      throw new IllegalArgumentException(
-          "An API key must be specified.");
-    }
-
-    OfflineAuth offlineAuth = new OfflineAuth();
-    offlineAuth.applicationName = applicationName;
-    offlineAuth.apiKey = apiKey;
-
-    return offlineAuth;
-  }
-
-  /**
-   * Creates offline-friendly auth object using a clientSecretsJson file path.
-   *
-   * Use this method when you need to store the resulting OfflineAuth for later use.
-   * Otherwise, you should create a {@link Genomics} object directly using
-   * {@code fromClientSecretsFile}.
-   *
-   * @param clientSecretsFilepath {@code client_secrets.json} file path.
-   * @return An OfflineAuth object that can be passed to {@code fromOfflineAuth}
-   * @throws IOException
-   */
-  public OfflineAuth getOfflineAuthFromClientSecretsFile(String clientSecretsFilepath)
-      throws IOException {
-    if (clientSecretsFilepath == null) {
-      throw new IllegalArgumentException(
-          "A client secrets file path must be specified.");
-    }
-
-    clientSecretsFilepath.replaceFirst("^~", System.getProperty("user.home"));
-    File clientSecretsFile = new File(clientSecretsFilepath);
-    Credential credential = makeCredential(clientSecretsFile);
-    return createOfflineAuth(credential, clientSecretsFilepath);
-  }
-
-  /**
-   * Creates offline-friendly auth object using a credential object.
-   *
-   * Use this method when your application has already performed the oauth
-   * flow (e.g., Google Cloud Dataflow) and you need to store the resulting
-   * OfflineAuth for later use.  
+   * Create a new genomics stub from the given OfflineAuth object.
    * 
-   * Otherwise, you should create a {@link Genomics} object directly using
-   * {@code fromClientSecretsFile}.
-   *
-   * @param credential
-   * @param clientSecretsFilepath {@code client_secrets.json} file path.
-   * @return An OfflineAuth object that can be passed to {@code fromOfflineAuth}
-   * @throws IOException
+   * @param auth The OfflineAuth
+   * @return The new {@code Genomics} stub
    */
-  public OfflineAuth getOfflineAuthFromCredential(Credential credential, String clientSecretsFilepath)
-      throws IOException {
-    if (credential == null) {
-      throw new IllegalArgumentException(
-          "A credential object must be specified.");
-    }
-    if (clientSecretsFilepath == null) {
-        throw new IllegalArgumentException(
-            "A client secrets file path must be specified.");
-    }
-    return createOfflineAuth(credential, clientSecretsFilepath);
-  }
-  
-  private OfflineAuth createOfflineAuth(Credential credential, String clientSecretsFilepath)
-      throws IOException {
-
-    OfflineAuth offlineAuth = new OfflineAuth();
-    offlineAuth.applicationName = applicationName;
-    
-    offlineAuth.accessToken = credential.getAccessToken();
-    offlineAuth.refreshToken = credential.getRefreshToken();
-    clientSecretsFilepath.replaceFirst("^~", System.getProperty("user.home"));
-    File clientSecretsFile = new File(clientSecretsFilepath);
-    offlineAuth.clientSecretsString = Files.toString(clientSecretsFile, Charsets.UTF_8);
-
-    return offlineAuth;
+  public Genomics fromOfflineAuth(OfflineAuth auth) {
+    Preconditions.checkNotNull(auth);
+    return fromOfflineAuth(getGenomicsBuilder(), auth).build();
   }
 
-  public static class OfflineAuth implements Serializable {
-    public String applicationName;
-    public String accessToken;
-    public String refreshToken;
-    public String clientSecretsString;
-    public String apiKey;
- 
-    public GenomicsFactory getDefaultFactory() throws GeneralSecurityException, IOException {
-      return GenomicsFactory.builder(applicationName).build();
+  /**
+   * Prepare an AbstractGoogleJsonClient.Builder with the given OfflineAuth object.
+   *
+   * @param builder The builder to be prepared.
+   * @param auth The OfflineAuth
+   * @return The passed in builder, for easy chaining.
+   */
+  public <T extends AbstractGoogleJsonClient.Builder> T fromOfflineAuth(T builder, OfflineAuth auth) {
+    Preconditions.checkNotNull(builder);
+    Preconditions.checkNotNull(auth);
+    if(auth.hasApiKey()) {
+      return fromApiKey(builder, auth.getApiKey());
     }
-
-    /**
-     * Create a {@link Genomics} stub.
-     *
-     * @return The new {@code Genomics} stub
-     * @param factory The factory used to generate the Genomics object
-     */
-    public Genomics getGenomics(GenomicsFactory factory) throws IOException {
-      return setupAuthentication(factory, factory.getGenomicsBuilder()).build();
-    }
-
-    /**
-     * Setup authentication on an AbstractGoogleJsonClient.Builder using the saved credentials.
-     *
-     * @return The passed in builder, for easy chaining.
-     * @param factory The factory used to setup the authentication.
-     * @param builder The builder to setup authentication on
-     */
-    public <T extends AbstractGoogleJsonClient.Builder> T setupAuthentication(
-        GenomicsFactory factory, T builder) throws IOException {
-      if (clientSecretsString == null) {
-        return factory.fromApiKey(builder, apiKey);
-      }
-
-      return factory.prepareBuilder(builder, new GoogleCredential.Builder()
-          .setTransport(factory.httpTransport)
-          .setJsonFactory(factory.jsonFactory)
-          .setClientSecrets(GoogleClientSecrets.load(factory.jsonFactory,
-              new StringReader(clientSecretsString)))
-          .build()
-          .setAccessToken(accessToken)
-          .setRefreshToken(refreshToken), new CommonGoogleClientRequestInitializer(apiKey));
-    }
-  
-    /**
-     * Convert the information in an OfflineAuth instance to a UserCredentials object.
-     * 
-     * Specifically, gRPC uses the new Google OAuth library.  See https://github.com/google/google-auth-library-java
-     * 
-     * @return The UserCredentials object.
-     * @throws IOException
-     * @throws GeneralSecurityException
-     */
-    public UserCredentials getUserCredentials() throws IOException, GeneralSecurityException {
-      Preconditions.checkState(hasUserCredentials(),
-          "Authorization needed.  (An API key is not sufficient for this usage.)");
-      GoogleClientSecrets secrets = GoogleClientSecrets.load(getDefaultFactory().jsonFactory,
-          new StringReader(clientSecretsString));
-      UserCredentials creds = new UserCredentials(secrets.getDetails().getClientId(),
-          secrets.getDetails().getClientSecret(), refreshToken);
-      return creds;
-    }
-    
-    /**
-     * @return Whether a UserCredentials object can be constructed from the information in this OfflineAuth.
-     */
-    public boolean hasUserCredentials() {
-      return null != clientSecretsString && null != refreshToken;
-    }
-    
-    /**
-     * @return Whether an api key is in this OfflineAuth.
-     */
-    public boolean hasApiKey() {
-      return null != apiKey;
-    }
+    return fromCredential(builder, auth.getCredential());
   }
 }

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
@@ -14,7 +14,6 @@
 package com.google.cloud.genomics.utils;
 
 import java.io.IOException;
-import java.security.GeneralSecurityException;
 import java.util.List;
 
 import com.google.api.services.genomics.Genomics;
@@ -44,13 +43,11 @@ public class GenomicsUtils {
    * @param auth The OfflineAuth for the API request.
    * @return The list of readGroupSetIds in the dataset.
    * @throws IOException If dataset does not contain any readGroupSets.
-   * @throws GeneralSecurityException
    */
-  public static List<String> getReadGroupSetIds(String datasetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
+  public static List<String> getReadGroupSetIds(String datasetId, OfflineAuth auth) throws IOException {
     List<String> output = Lists.newArrayList();
-    Iterable<ReadGroupSet> rgs = Paginator.ReadGroupSets.create(
-        auth.getGenomics(auth.getDefaultFactory()))
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
+    Iterable<ReadGroupSet> rgs = Paginator.ReadGroupSets.create(genomics)
         .search(new SearchReadGroupSetsRequest().setDatasetIds(Lists.newArrayList(datasetId)),
             "readGroupSets/id,nextPageToken");
     for (ReadGroupSet r : rgs) {
@@ -68,12 +65,11 @@ public class GenomicsUtils {
    * @param readGroupSetId The id of the readGroupSet to query.
    * @param auth The OfflineAuth for the API request.
    * @return The referenceSetId for the redGroupSet (which may be null).
-   * @throws IOException
-   * @throws GeneralSecurityException
+   * @throws IOException 
    */
-  public static String getReferenceSetId(String readGroupSetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
-    Genomics genomics = auth.getGenomics(auth.getDefaultFactory());
+  public static String getReferenceSetId(String readGroupSetId, OfflineAuth auth)
+      throws IOException {
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
     ReadGroupSet readGroupSet = genomics.readgroupsets().get(readGroupSetId)
         .setFields("referenceSetId").execute();
     return readGroupSet.getReferenceSetId();
@@ -85,12 +81,11 @@ public class GenomicsUtils {
    * @param readGroupSetId The id of the readGroupSet to query.
    * @param auth The OfflineAuth for the API request.
    * @return The list of reference bounds in the variantSet.
-   * @throws IOException
-   * @throws GeneralSecurityException
+   * @throws IOException 
    */
-  public static List<CoverageBucket> getCoverageBuckets(String readGroupSetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
-    Genomics genomics = auth.getGenomics(auth.getDefaultFactory());
+  public static List<CoverageBucket> getCoverageBuckets(String readGroupSetId, OfflineAuth auth)
+      throws IOException {
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
     ListCoverageBucketsResponse response =
         genomics.readgroupsets().coveragebuckets().list(readGroupSetId).execute();
     // Requests of this form return one result per reference name, so therefore many fewer than
@@ -110,11 +105,10 @@ public class GenomicsUtils {
    * @param auth The OfflineAuth for the API request.
    * @return The list of references in the referenceSet.
    * @throws IOException
-   * @throws GeneralSecurityException
    */
-  public static Iterable<Reference> getReferences(String referenceSetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
-    Genomics genomics = auth.getGenomics(auth.getDefaultFactory());
+  public static Iterable<Reference> getReferences(String referenceSetId, OfflineAuth auth)
+      throws IOException {
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
     return Paginator.References.create(
         genomics).search(new SearchReferencesRequest().setReferenceSetId(referenceSetId));
   }
@@ -126,13 +120,12 @@ public class GenomicsUtils {
    * @param auth The OfflineAuth for the API request.
    * @return The list of variantSetIds in the dataset.
    * @throws IOException If dataset does not contain any variantSets.
-   * @throws GeneralSecurityException
    */
-  public static List<String> getVariantSetIds(String datasetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
+  public static List<String> getVariantSetIds(String datasetId, OfflineAuth auth)
+      throws IOException {
     List<String> output = Lists.newArrayList();
-    Iterable<VariantSet> vs = Paginator.Variantsets.create(
-        auth.getGenomics(auth.getDefaultFactory()))
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
+    Iterable<VariantSet> vs = Paginator.Variantsets.create(genomics)
         .search(new SearchVariantSetsRequest().setDatasetIds(Lists.newArrayList(datasetId)),
             "variantSets/id,nextPageToken");
     for (VariantSet v : vs) {
@@ -151,14 +144,12 @@ public class GenomicsUtils {
    * @param auth The OfflineAuth for the API request.
    * @return The list of callSet names in the variantSet.
    * @throws IOException If variantSet does not contain any CallSets.
-   * @throws GeneralSecurityException
-
    */
-  public static List<String> getCallSetsNames(String variantSetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
+  public static List<String> getCallSetsNames(String variantSetId, OfflineAuth auth)
+      throws IOException {
     List<String> output = Lists.newArrayList();
-    Iterable<CallSet> cs = Paginator.Callsets.create(
-        auth.getGenomics(auth.getDefaultFactory()))
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
+    Iterable<CallSet> cs = Paginator.Callsets.create(genomics)
         .search(new SearchCallSetsRequest().setVariantSetIds(Lists.newArrayList(variantSetId)),
             "callSets/name,nextPageToken");
     for (CallSet c : cs) {
@@ -177,11 +168,10 @@ public class GenomicsUtils {
    * @param auth The OfflineAuth for the API request.
    * @return The list of reference bounds in the variantSet.
    * @throws IOException
-   * @throws GeneralSecurityException
    */
-  public static List<ReferenceBound> getReferenceBounds(String variantSetId, GenomicsFactory.OfflineAuth auth)
-      throws IOException, GeneralSecurityException {
-    Genomics genomics = auth.getGenomics(auth.getDefaultFactory());
+  public static List<ReferenceBound> getReferenceBounds(String variantSetId, OfflineAuth auth)
+      throws IOException {
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
     VariantSet variantSet = genomics.variantsets().get(variantSetId).execute();
     return variantSet.getReferenceBounds();
   }  

--- a/src/main/java/com/google/cloud/genomics/utils/OfflineAuth.java
+++ b/src/main/java/com/google/cloud/genomics/utils/OfflineAuth.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.security.GeneralSecurityException;
+
+import com.google.api.client.auth.oauth2.ClientParametersAuthentication;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.UserCredentials;
+import com.google.common.base.Preconditions;
+
+/**
+ * The purpose of the OfflineAuth class is to encapsulate an apiKey or stored user credential
+ * for offline use in pipeline systems such as Dataflow or Spark.
+ * 
+ * If the OfflineAuth object contains neither an apiKey or user credential, it will fall back to 
+ * the Application Default Credential.
+ * 
+ * For more information about auth, please see:
+ * <ul>
+ *    <li>https://developers.google.com/identity/protocols/application-default-credentials
+ *    <li>https://developers.google.com/api-client-library/java/google-oauth-java-client/oauth2
+ *    <li>https://github.com/google/google-api-java-client/tree/master/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2
+ *    <li>https://github.com/google/google-oauth-java-client
+ *    <li>https://github.com/google/google-auth-library-java
+ * </ul>
+ */
+@SuppressWarnings("serial")
+public class OfflineAuth implements Serializable {
+  private String apiKey;
+  private String clientId;
+  private String clientSecret;
+  private String refreshToken;
+  
+  /**
+   * Creates an empty offline-friendly auth object.
+   *
+   * Use this method when your application will fall back to using the Application Default
+   * Credential (e.g., via Google Cloud Dataflow) but the code interface takes an OfflineAuth object
+   * so that it could alternatively use a user credential or an apiKey.
+   */
+  public OfflineAuth() {}
+
+  /**
+   * Creates offline-friendly auth object using a credential object.
+   *
+   * Use this method when your application has already performed the oauth
+   * flow and needs to store and use the credential later in an offline
+   * manner (e.g., via Google Cloud Dataflow).
+   * 
+   * @param credential The credential to be used for requests.
+   */
+  public OfflineAuth(Credential credential) {
+    Preconditions.checkNotNull(credential);
+    ClientParametersAuthentication clientParams =
+        (ClientParametersAuthentication) credential.getClientAuthentication();
+    this.clientId = clientParams.getClientId();
+    this.clientSecret = clientParams.getClientSecret();
+    this.refreshToken = credential.getRefreshToken();
+  }
+
+  /**
+   * Creates offline-friendly auth object using an apiKey.
+   *
+   * Use this method when you need to store the resulting OfflineAuth for later use.
+   *
+   * @param apiKey The API key of the Google Cloud Platform project to be used for requests.
+   */
+  public OfflineAuth(String apiKey) {
+    Preconditions.checkNotNull(apiKey);
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * @return Whether an api key is stored in this OfflineAuth.
+   */
+  public boolean hasApiKey() {
+    return null != apiKey;
+  }
+  
+  /**
+   * @return the apiKey
+   */
+  public String getApiKey() {
+    return apiKey;
+  }
+
+  /**
+   * @return Whether a credential is stored in this OfflineAuth.
+   */
+  public boolean hasStoredCredential() {
+    return null != refreshToken;
+  }
+
+  /**
+   * @return The stored clientId or null if the Application Default Credential is to be used.
+   */
+  public String getClientId() {
+    return clientId;
+  }
+
+  /**
+   * @return The stored clientSecret or null if the Application Default Credential is to be used.
+   */
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  /**
+   * @return The stored refreshToken or null if the Application Default Credential is to be used.
+   */
+  public String getRefreshToken() {
+    return refreshToken;
+  }
+  
+  /**
+   * Return the stored user credential, if applicable, or fall back to the Application Default Credential.
+   * 
+   * @return The com.google.api.client.auth.oauth2.Credential object.
+   */
+  public Credential getCredential() {
+    if (hasStoredCredential()) {
+      HttpTransport httpTransport;
+      try {
+        httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+      } catch (IOException | GeneralSecurityException e) {
+        throw new RuntimeException("Could not create HTTPS transport for use in credential creation", e);
+      }
+
+      return new GoogleCredential.Builder()
+      .setJsonFactory(JacksonFactory.getDefaultInstance())
+      .setTransport(httpTransport)
+      .setClientSecrets(getClientId(), getClientSecret())
+      .build()
+      .setRefreshToken(getRefreshToken());
+    }
+    return CredentialFactory.getApplicationDefaultCredential();
+  }
+  
+  /**
+   * Return the stored user credentials, if applicable, or fall back to the Application Default Credentials.
+   * 
+   * Specifically, gRPC uses the new Google OAuth library.  See https://github.com/google/google-auth-library-java
+   * 
+   * @return The com.google.auth.Credentials object.
+   */
+  public GoogleCredentials getCredentials() {
+    if (hasStoredCredential()) {
+      return new UserCredentials(clientId, clientSecret, refreshToken);
+    }
+    return CredentialFactory.getApplicationDefaultCredentials();
+  }
+
+}

--- a/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
@@ -130,7 +130,7 @@ public class ShardUtils {
    */
   public static ImmutableList<StreamVariantsRequest> getVariantRequests(final String variantSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException, GeneralSecurityException {
     Iterable<Contig> shards = getAllShardsInVariantSet(variantSetId,
         sexChromosomeFilter, numberOfBasesPerShard, auth);
     return FluentIterable.from(shards)
@@ -157,7 +157,7 @@ public class ShardUtils {
   @Deprecated // Remove this when fully migrated to gRPC.
   public static ImmutableList<SearchVariantsRequest> getPaginatedVariantRequests(final String variantSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException, GeneralSecurityException {
     Iterable<Contig> shards = getAllShardsInVariantSet(variantSetId,
         sexChromosomeFilter, numberOfBasesPerShard, auth);
     return FluentIterable.from(shards)
@@ -248,7 +248,7 @@ public class ShardUtils {
    */
   public static ImmutableList<StreamReadsRequest> getReadRequests(final String readGroupSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException, GeneralSecurityException {
     Iterable<Contig> shards = getAllShardsInReadGroupSet(readGroupSetId, sexChromosomeFilter,
         numberOfBasesPerShard, auth);
     return FluentIterable.from(shards)
@@ -262,7 +262,7 @@ public class ShardUtils {
 
   private static List<Contig> getAllShardsInVariantSet(String variantSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException, GeneralSecurityException {
     List<Contig> contigs = getContigsInVariantSet(variantSetId, sexChromosomeFilter, auth);
     return ShardUtils.getAllShardsForContigs(contigs, numberOfBasesPerShard);
   }
@@ -280,7 +280,7 @@ public class ShardUtils {
    * @throws GeneralSecurityException 
    */
   private static List<Contig> getContigsInVariantSet(String variantSetId,
-      SexChromosomeFilter sexChromosomeFilter, GenomicsFactory.OfflineAuth auth)
+      SexChromosomeFilter sexChromosomeFilter, OfflineAuth auth)
           throws IOException, GeneralSecurityException {
     List<Contig> contigs = Lists.newArrayList();
     for (ReferenceBound bound : GenomicsUtils.getReferenceBounds(variantSetId, auth)) {
@@ -296,7 +296,7 @@ public class ShardUtils {
 
   private static List<Contig> getAllShardsInReadGroupSet(String readGroupSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      GenomicsFactory.OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException, GeneralSecurityException {
     List<Contig> contigs = getContigsInReadGroupSet(readGroupSetId, sexChromosomeFilter, auth);
     return ShardUtils.getAllShardsForContigs(contigs, numberOfBasesPerShard);
   }
@@ -313,7 +313,7 @@ public class ShardUtils {
    * @throws GeneralSecurityException 
    */
   private static List<Contig> getContigsInReadGroupSet(String readGroupSetId,
-      SexChromosomeFilter sexChromosomeFilter, GenomicsFactory.OfflineAuth auth)
+      SexChromosomeFilter sexChromosomeFilter, OfflineAuth auth)
           throws IOException, GeneralSecurityException {
     List<Contig> contigs = Lists.newArrayList();
     for (CoverageBucket bucket : GenomicsUtils.getCoverageBuckets(readGroupSetId, auth)) {

--- a/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ShardUtils.java
@@ -126,11 +126,10 @@ public class ShardUtils {
    * @param auth The OfflineAuth to be used to get the reference bounds for the variantSet.
    * @return The shuffled list of sharded request objects.
    * @throws IOException 
-   * @throws GeneralSecurityException 
    */
   public static ImmutableList<StreamVariantsRequest> getVariantRequests(final String variantSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException {
     Iterable<Contig> shards = getAllShardsInVariantSet(variantSetId,
         sexChromosomeFilter, numberOfBasesPerShard, auth);
     return FluentIterable.from(shards)
@@ -152,12 +151,11 @@ public class ShardUtils {
    * @param auth The OfflineAuth to be used to get the reference bounds for the variantSet.
    * @return The shuffled list of sharded request objects.
    * @throws IOException 
-   * @throws GeneralSecurityException 
    */
   @Deprecated // Remove this when fully migrated to gRPC.
   public static ImmutableList<SearchVariantsRequest> getPaginatedVariantRequests(final String variantSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException {
     Iterable<Contig> shards = getAllShardsInVariantSet(variantSetId,
         sexChromosomeFilter, numberOfBasesPerShard, auth);
     return FluentIterable.from(shards)
@@ -244,11 +242,10 @@ public class ShardUtils {
    * @param auth The OfflineAuth to be used to get the reference bounds for the variantSet.
    * @return The shuffled list of sharded request objects.
    * @throws IOException 
-   * @throws GeneralSecurityException 
    */
   public static ImmutableList<StreamReadsRequest> getReadRequests(final String readGroupSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException {
     Iterable<Contig> shards = getAllShardsInReadGroupSet(readGroupSetId, sexChromosomeFilter,
         numberOfBasesPerShard, auth);
     return FluentIterable.from(shards)
@@ -262,7 +259,7 @@ public class ShardUtils {
 
   private static List<Contig> getAllShardsInVariantSet(String variantSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException {
     List<Contig> contigs = getContigsInVariantSet(variantSetId, sexChromosomeFilter, auth);
     return ShardUtils.getAllShardsForContigs(contigs, numberOfBasesPerShard);
   }
@@ -277,11 +274,9 @@ public class ShardUtils {
    *        handled in the result.
    * @return The list of all references in the variantSet.
    * @throws IOException
-   * @throws GeneralSecurityException 
    */
   private static List<Contig> getContigsInVariantSet(String variantSetId,
-      SexChromosomeFilter sexChromosomeFilter, OfflineAuth auth)
-          throws IOException, GeneralSecurityException {
+      SexChromosomeFilter sexChromosomeFilter, OfflineAuth auth) throws IOException {
     List<Contig> contigs = Lists.newArrayList();
     for (ReferenceBound bound : GenomicsUtils.getReferenceBounds(variantSetId, auth)) {
       if (sexChromosomeFilter == SexChromosomeFilter.EXCLUDE_XY
@@ -296,7 +291,7 @@ public class ShardUtils {
 
   private static List<Contig> getAllShardsInReadGroupSet(String readGroupSetId,
       SexChromosomeFilter sexChromosomeFilter, long numberOfBasesPerShard,
-      OfflineAuth auth) throws IOException, GeneralSecurityException {
+      OfflineAuth auth) throws IOException {
     List<Contig> contigs = getContigsInReadGroupSet(readGroupSetId, sexChromosomeFilter, auth);
     return ShardUtils.getAllShardsForContigs(contigs, numberOfBasesPerShard);
   }
@@ -310,11 +305,9 @@ public class ShardUtils {
    *        handled in the result.
    * @return The list of all references in the readGroupSet.
    * @throws IOException
-   * @throws GeneralSecurityException 
    */
   private static List<Contig> getContigsInReadGroupSet(String readGroupSetId,
-      SexChromosomeFilter sexChromosomeFilter, OfflineAuth auth)
-          throws IOException, GeneralSecurityException {
+      SexChromosomeFilter sexChromosomeFilter, OfflineAuth auth) throws IOException {
     List<Contig> contigs = Lists.newArrayList();
     for (CoverageBucket bucket : GenomicsUtils.getCoverageBuckets(readGroupSetId, auth)) {
       if (sexChromosomeFilter == SexChromosomeFilter.EXCLUDE_XY

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/Example.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/Example.java
@@ -17,12 +17,7 @@ import com.google.genomics.v1.StreamingVariantServiceGrpc.StreamingVariantServic
 public class Example {
   
   public static void main(String[] args) throws Exception {
-    ManagedChannel channel;
-    if(args.length == 1) {
-      channel = GenomicsChannel.fromApiKey(args[0]);
-    } else {
-      channel = GenomicsChannel.fromDefaultCreds();
-    }
+    ManagedChannel channel = GenomicsChannel.fromDefaultCreds();
 
     // Regular RPC example: list all reference set assembly ids.
     ReferenceServiceV1BlockingStub refStub =

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadStreamIterator.java
@@ -20,7 +20,7 @@ import java.security.GeneralSecurityException;
 import java.util.Iterator;
 import java.util.List;
 
-import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
+import com.google.cloud.genomics.utils.OfflineAuth;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardBoundary.Requirement;
 import com.google.common.base.Predicate;

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
@@ -20,7 +20,7 @@ import java.security.GeneralSecurityException;
 import java.util.Iterator;
 import java.util.List;
 
-import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
+import com.google.cloud.genomics.utils.OfflineAuth;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardBoundary.Requirement;
 import com.google.common.base.Predicate;

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsFactoryITCase.java
@@ -16,19 +16,14 @@
 package com.google.cloud.genomics.utils;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpTransport;
@@ -38,12 +33,7 @@ import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
-import com.google.api.client.util.store.FileDataStoreFactory;
 import com.google.api.services.genomics.Genomics;
-import com.google.api.services.genomics.GenomicsScopes;
-import com.google.api.services.storage.Storage;
-import com.google.api.services.storage.StorageScopes;
-import com.google.common.collect.Lists;
 
 @RunWith(JUnit4.class)
 public class GenomicsFactoryITCase {

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
@@ -18,50 +18,51 @@ package com.google.cloud.genomics.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-
 import org.hamcrest.CoreMatchers;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class GenomicsUtilsITCase {
   
-  static IntegrationTestHelper helper;
+  @Test
+  public void testGetReadGroupSetIds() throws Exception {
+    assertThat(GenomicsUtils.getReadGroupSetIds(IntegrationTestHelper.PLATINUM_GENOMES_DATASET,
+        IntegrationTestHelper.getAuthFromApiKey()),
+        CoreMatchers.allOf(CoreMatchers.hasItems(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS))); 
+  }
 
-  @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
-    helper = new IntegrationTestHelper();
+  @Test
+  public void testGetReferenceSetIdForReadGroupSet() throws Exception {
+    assertEquals(IntegrationTestHelper.PLATINUM_GENOMES_REFERENCE_SET_ID,
+        GenomicsUtils.getReferenceSetId(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0],
+            IntegrationTestHelper.getAuthFromApiKey()));
   }
   
   @Test
-  public void testGetReadGroupSetIds() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getReadGroupSetIds(helper.PLATINUM_GENOMES_DATASET, helper.getAuth()),
-        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_READGROUPSETS))); 
+  public void testGetVariantSetIds() throws Exception {
+    assertThat(GenomicsUtils.getVariantSetIds(IntegrationTestHelper.PLATINUM_GENOMES_DATASET,
+        IntegrationTestHelper.getAuthFromApiKey()),
+        CoreMatchers.allOf(CoreMatchers.hasItems(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET))); 
   }
 
   @Test
-  public void testGetReferenceSetIdForReadGroupSet() throws IOException, GeneralSecurityException {
-    assertEquals(helper.PLATINUM_GENOMES_REFERENCE_SET_ID,
-        GenomicsUtils.getReferenceSetId(helper.PLATINUM_GENOMES_READGROUPSETS[0], helper.getAuth()));
+  public void testGetCallSetsNames() throws Exception {
+    assertThat(GenomicsUtils.getCallSetsNames(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+        IntegrationTestHelper.getAuthFromApiKey()),
+        CoreMatchers.allOf(CoreMatchers.hasItems(IntegrationTestHelper.PLATINUM_GENOMES_CALLSET_NAMES))); 
+  }
+
+  @Test
+  public void testGetReferenceBounds() throws Exception {
+    assertThat(GenomicsUtils.getReferenceBounds(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+        IntegrationTestHelper.getAuthFromApiKey()),
+        CoreMatchers.allOf(CoreMatchers.hasItems(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET_BOUNDS))); 
+  }
+
+  @Test
+  public void testGetReferenceBoundsApplicationDefaultCredential() throws Exception {
+    assertThat(GenomicsUtils.getReferenceBounds(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+        IntegrationTestHelper.getAuthFromApplicationDefaultCredential()),
+        CoreMatchers.allOf(CoreMatchers.hasItems(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET_BOUNDS))); 
   }
   
-  @Test
-  public void testGetVariantSetIds() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getVariantSetIds(helper.PLATINUM_GENOMES_DATASET, helper.getAuth()),
-        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_VARIANTSET))); 
-  }
-
-  @Test
-  public void testGetCallSetsNames() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getCallSetsNames(helper.PLATINUM_GENOMES_VARIANTSET, helper.getAuth()),
-        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_CALLSET_NAMES))); 
-  }
-
-  @Test
-  public void testGetReferenceBounds() throws IOException, GeneralSecurityException {
-    assertThat(GenomicsUtils.getReferenceBounds(helper.PLATINUM_GENOMES_VARIANTSET, helper.getAuth()),
-        CoreMatchers.allOf(CoreMatchers.hasItems(helper.PLATINUM_GENOMES_VARIANTSET_BOUNDS))); 
-  }
-
 }

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 import com.google.api.services.genomics.model.ReferenceBound;
-import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth;
 
 /**
  * Helpers for common tasks involved in integration tests against the Genomics API.
@@ -100,25 +99,21 @@ public class IntegrationTestHelper {
     new ReferenceBound().setReferenceName("chrY").setUpperBound(60032946L)
   };
 
-  private final String API_KEY = System.getenv("GOOGLE_API_KEY");
-  private final OfflineAuth auth;
+  private static final String API_KEY = System.getenv("GOOGLE_API_KEY");
   
-  public IntegrationTestHelper() throws IOException, GeneralSecurityException {
-    assertNotNull("You must set the GOOGLE_API_KEY environment variable for this test.", API_KEY);
-     auth = GenomicsFactory.builder("integration test").build().getOfflineAuthFromApiKey(API_KEY);
-  }
-
   /**
    * @return the API_KEY
    */
-  public String getAPI_KEY() {
+  public static String getAPI_KEY() {
     return API_KEY;
   }
 
-  /**
-   * @return the auth
-   */
-  public OfflineAuth getAuth() {
-    return auth;
+  public static OfflineAuth getAuthFromApiKey() {
+    assertNotNull("You must set the GOOGLE_API_KEY environment variable for this test.", API_KEY);
+    return new OfflineAuth(API_KEY);
+  }
+  
+  public static OfflineAuth getAuthFromApplicationDefaultCredential() {
+    return new OfflineAuth();
   }
 }

--- a/src/test/java/com/google/cloud/genomics/utils/OfflineAuthITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/OfflineAuthITCase.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class OfflineAuthITCase {
+  
+  @Test
+  public void testOfflineAuthFromApplicationDefaultCredential() throws Exception {
+    OfflineAuth auth = new OfflineAuth();
+    assertFalse(auth.hasApiKey());
+    assertFalse(auth.hasStoredCredential());
+    assertNotNull(auth.getCredential());
+    assertNotNull(auth.getCredentials());
+    assertNull(auth.getClientId());
+    assertNull(auth.getClientSecret());
+    assertNull(auth.getRefreshToken());
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/OfflineAuthTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/OfflineAuthTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.Test;
+
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.jackson2.JacksonFactory;
+
+public class OfflineAuthTest {
+
+  @Test
+  public void testOfflineAuthFromApiKey() throws Exception {
+    OfflineAuth auth = new OfflineAuth("xyz");
+    assertTrue(auth.hasApiKey());
+    assertFalse(auth.hasStoredCredential());
+    assertNotNull(auth.getCredential());
+    assertNotNull(auth.getCredentials());
+    assertNull(auth.getClientId());
+    assertNull(auth.getClientSecret());
+    assertNull(auth.getRefreshToken());
+  }
+
+  @Test
+  public void testOfflineAuth_apiKeyIsSerializable() throws Exception {
+    OfflineAuth auth = new OfflineAuth("xyz");
+
+    // This mimics the serialization flow used by Dataflow pipelines.
+    ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream());
+    oos.writeObject(auth);
+  }
+
+  @Test
+  public void testOfflineAuth_credentialIsSerializable() throws Exception {
+    Credential credential = new GoogleCredential.Builder()
+      .setJsonFactory(JacksonFactory.getDefaultInstance())
+      .setTransport(GoogleNetHttpTransport.newTrustedTransport())
+      .setClientSecrets("theClientId", "theClientSecret")
+      .build()
+      .setRefreshToken("theRefreshToken");
+    OfflineAuth auth = new OfflineAuth(credential);
+
+    // This mimics the serialization flow used by Dataflow pipelines.
+    ObjectOutputStream oos = new ObjectOutputStream(new ByteArrayOutputStream());
+    oos.writeObject(auth);
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/utils/OfflineAuthTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/OfflineAuthTest.java
@@ -18,11 +18,13 @@ package com.google.cloud.genomics.utils;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import com.google.api.client.auth.oauth2.Credential;
@@ -37,11 +39,20 @@ public class OfflineAuthTest {
     OfflineAuth auth = new OfflineAuth("xyz");
     assertTrue(auth.hasApiKey());
     assertFalse(auth.hasStoredCredential());
-    assertNotNull(auth.getCredential());
-    assertNotNull(auth.getCredentials());
     assertNull(auth.getClientId());
     assertNull(auth.getClientSecret());
     assertNull(auth.getRefreshToken());
+
+    // Depending upon the environment in which these unit tests are run, the
+    // Application Default Credentials may or may not be available.
+    try {
+      Credential cred = auth.getCredential();
+      assertNotNull(cred);
+      assertNotNull(auth.getCredentials());
+    } catch (Exception e) {
+      assertThat(e.getMessage(),
+          CoreMatchers.containsString("Unable to get application default credentials."));
+    }
   }
 
   @Test

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
@@ -17,10 +17,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.util.Arrays;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter;
@@ -29,97 +27,90 @@ import com.google.genomics.v1.StreamVariantsRequest;
 
 public class ShardUtilsITCase {
 
-  static IntegrationTestHelper helper;
-  
-  @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
-    helper = new IntegrationTestHelper();
-  }
-
   @Test
   public void testGetVariantRequestsStringSexChromosomeFilterLongOfflineAuth() throws IOException, GeneralSecurityException {
 
     StreamVariantsRequest[] EXPECTED_RESULT_XY = {
         new Contig("chrX", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chrX", 150000000L, 156231278L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chrY", 0L, 60032946L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET)
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
     };
     
     StreamVariantsRequest[] EXPECTED_RESULT = {
         new Contig("chr1", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr1", 150000000L, 250226910L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr10", 0L, 136466007L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr11", 0L, 135762137L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr12", 0L, 134049696L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr13", 0L, 115800144L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr14", 0L, 107857350L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr15", 0L, 103000009L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr16", 0L, 90760361L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr17", 0L, 81983044L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr18", 0L, 78776233L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr19", 0L, 59544813L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr2", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr2", 150000000L, 243800708L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr20", 0L, 62993757L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr21", 0L, 48724643L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr22", 0L, 51891601L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr3", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr3", 150000000L, 198316350L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr4", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr4", 150000000L, 191970744L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr5", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr5", 150000000L, 181054248L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr6", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr6", 150000000L, 171796962L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr7", 0L, 150000000L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr7", 150000000L, 159737113L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr8", 0L, 147299246L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chr9", 0L, 142027288L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
         new Contig("chrM", 0L, 1000001L)
-        .getStreamVariantsRequest(helper.PLATINUM_GENOMES_VARIANTSET)
+        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
     };
     
     // These shards are "too big" to use in practice but for this test it keeps the
     // expected result from getting crazy long.
-    assertThat(ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-        SexChromosomeFilter.EXCLUDE_XY, 150000000L, helper.getAuth()),
+    assertThat(ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+        SexChromosomeFilter.EXCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
     
     // Include sex chromosomes this time.
-    assertThat(ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-        SexChromosomeFilter.INCLUDE_XY, 150000000L, helper.getAuth()),
+    assertThat(ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+        SexChromosomeFilter.INCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT),
             CoreMatchers.hasItems(EXPECTED_RESULT_XY)));
   }
@@ -129,85 +120,85 @@ public class ShardUtilsITCase {
 
     StreamReadsRequest[] EXPECTED_RESULT_XY = {
         new Contig("chrX", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chrX", 150000000L, 155270560L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chrY", 0L, 59373566L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0])
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0])
     };
     
     StreamReadsRequest[] EXPECTED_RESULT = {
         new Contig("chr1", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr1", 150000000L, 249250621L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr10", 0L, 135534747L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr11", 0L, 135006516L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr12", 0L, 133851895L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr13", 0L, 115169878L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr14", 0L, 107349540L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr15", 0L, 102531392L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr16", 0L, 90354753L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr17", 0L, 81195210L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr18", 0L, 78077248L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr19", 0L,  59128983L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr2", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr2", 150000000L, 243199373L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr20", 0L, 63025520L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr21", 0L, 48129895L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr22", 0L, 51304566L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr3", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr3", 150000000L, 198022430L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr4", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr4", 150000000L, 191154276L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr5", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr5", 150000000L, 180915260L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr6", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr6", 150000000L, 171115067L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr7", 0L, 150000000L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr7", 150000000L, 159138663L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr8", 0L, 146364022L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chr9", 0L, 141213431L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         new Contig("chrM", 0L, 16571L)
-        .getStreamReadsRequest(helper.PLATINUM_GENOMES_READGROUPSETS[0])
+        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0])
     };
     
     // These shards are "too big" to use in practice but for this test it keeps the
     // expected result from getting crazy long.
-    assertThat(ShardUtils.getReadRequests(helper.PLATINUM_GENOMES_READGROUPSETS[0],
-        SexChromosomeFilter.EXCLUDE_XY, 150000000L, helper.getAuth()),
+    assertThat(ShardUtils.getReadRequests(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0],
+        SexChromosomeFilter.EXCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
     
     // Include sex chromosomes this time.
-    assertThat(ShardUtils.getReadRequests(helper.PLATINUM_GENOMES_READGROUPSETS[0],
-        SexChromosomeFilter.INCLUDE_XY, 150000000L, helper.getAuth()),
+    assertThat(ShardUtils.getReadRequests(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0],
+        SexChromosomeFilter.INCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT),
             CoreMatchers.hasItems(EXPECTED_RESULT_XY)));
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
@@ -44,7 +44,6 @@ public class FaultyGenomicsServerITCase {
   public static final String SERVER_NAME = "integrationTest";
   
   protected static Server server;
-  protected static IntegrationTestHelper helper;
   protected static ManagedChannel genomicsChannel;
   
   // Variable accessed by both the InProcess Server executor threads and the test thread.
@@ -65,8 +64,7 @@ public class FaultyGenomicsServerITCase {
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
-    helper = new IntegrationTestHelper();
-    genomicsChannel = GenomicsChannel.fromOfflineAuth(helper.getAuth());
+    genomicsChannel = GenomicsChannel.fromOfflineAuth(IntegrationTestHelper.getAuthFromApplicationDefaultCredential());
   }
 
   @AfterClass
@@ -133,13 +131,13 @@ public class FaultyGenomicsServerITCase {
   @Test
   public void testVariantRetries() {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-            helper.PLATINUM_GENOMES_BRCA1_REFERENCES, 1000000000L);
+        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+            IntegrationTestHelper.PLATINUM_GENOMES_BRCA1_REFERENCES, 1000000000L);
     VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0), 
         ShardBoundary.Requirement.STRICT, null);
     // Dev Note: this data currently comes back as 20 separate lists but this is controlled server-side.
     // We're using a pretty high fault rate here (25%) to ensure we see a few faults during each test run.
-    runRetryTest(iter, 0.25, helper.PLATINUM_GENOMES_BRCA1_EXPECTED_NUM_VARIANTS);
+    runRetryTest(iter, 0.25, IntegrationTestHelper.PLATINUM_GENOMES_BRCA1_EXPECTED_NUM_VARIANTS);
   }
   
 }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
@@ -18,6 +18,7 @@ import java.security.GeneralSecurityException;
 
 import org.junit.Test;
 
+import com.google.cloud.genomics.utils.IntegrationTestHelper;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.ImmutableList;
@@ -34,7 +35,7 @@ public class FaultyGenomicsServerITLongCase extends FaultyGenomicsServerITCase {
 
   // Create one long stream.
   private static final ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(
-      helper.PLATINUM_GENOMES_VARIANTSET, "chrY:0:60032946", 1000000000L);
+      IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET, "chrY:0:60032946", 1000000000L);
   private static final int EXPECTED_CHRY_NUM_VARIANTS = 5971309;
 
   @Test

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -35,28 +34,22 @@ import com.google.common.collect.ImmutableList;
 import com.google.genomics.v1.Read;
 import com.google.genomics.v1.StreamReadsRequest;
 import com.google.genomics.v1.StreamReadsResponse;
-import com.google.genomics.v1.Variant;
 
 
 public class ReadStreamIteratorITCase {
   // This small interval overlaps the Klotho SNP.
   static final String REFERENCES = "chr13:33628134:33628138";
-  static IntegrationTestHelper helper;
-  
-  @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
-    helper = new IntegrationTestHelper();
-  }
   
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        ShardUtils.getReadRequests(Collections.singletonList(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         REFERENCES, 100L);
     assertEquals(1, requests.size());
     
     Iterator<StreamReadsResponse> iter =
-        ReadStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
+        ReadStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0), 
             ShardBoundary.Requirement.OVERLAPS, null);
     
     assertTrue(iter.hasNext());
@@ -64,7 +57,8 @@ public class ReadStreamIteratorITCase {
     assertEquals(57, readResponse.getAlignmentsList().size());
     assertFalse(iter.hasNext());
 
-    iter = ReadStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0),
+    iter = ReadStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+        requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
     
     assertTrue(iter.hasNext());
@@ -78,12 +72,13 @@ public class ReadStreamIteratorITCase {
   // TODO https://github.com/googlegenomics/utils-java/issues/48
   public void testPartialResponses() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList(helper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        ShardUtils.getReadRequests(Collections.singletonList(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
         REFERENCES, 100L);
     assertEquals(1, requests.size());
     
     Iterator<StreamReadsResponse> iter =
-        ReadStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
+        ReadStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0), 
             ShardBoundary.Requirement.STRICT, "reads(alignments)");
     
     assertTrue(iter.hasNext());

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -23,7 +23,6 @@ import java.security.GeneralSecurityException;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -37,22 +36,16 @@ import com.google.genomics.v1.Variant;
 
 public class VariantStreamIteratorITCase {
 
-  static IntegrationTestHelper helper;
-
-  @BeforeClass
-  public static void setUpBeforeClass() throws Exception {
-    helper = new IntegrationTestHelper();
-  }
-
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-            helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+            IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =
-        VariantStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
+        VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0), 
             ShardBoundary.Requirement.OVERLAPS, null);
 
     assertTrue(iter.hasNext());
@@ -63,7 +56,8 @@ public class VariantStreamIteratorITCase {
     assertFalse(iter.hasNext());
     
     iter =
-        VariantStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
+        VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0), 
             ShardBoundary.Requirement.STRICT, null);
 
     assertTrue(iter.hasNext());
@@ -76,17 +70,19 @@ public class VariantStreamIteratorITCase {
   @Test
   public void testEmptyRegion() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
+        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
             "chrDoesNotExist:100:200", 100L);
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =
-        VariantStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0), 
+        VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0), 
             ShardBoundary.Requirement.OVERLAPS, null);
     assertFalse(iter.hasNext());
 
     iter =
-        VariantStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0),
+        VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0),
             ShardBoundary.Requirement.STRICT, null);
     assertFalse(iter.hasNext());
   }
@@ -96,12 +92,13 @@ public class VariantStreamIteratorITCase {
   // TODO https://github.com/googlegenomics/utils-java/issues/48
   public void testPartialResponses() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(helper.PLATINUM_GENOMES_VARIANTSET,
-            helper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+            IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =
-        VariantStreamIterator.enforceShardBoundary(helper.getAuth(), requests.get(0),
+        VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
+            requests.get(0),
             ShardBoundary.Requirement.STRICT, "variants(reference_name,start)");
 
     assertTrue(iter.hasNext());


### PR DESCRIPTION
* Use Application Default Credentials by default for both the Genomics REST and gRPC APIs.
* Refactor GenomicsFactory to extract credential creation and OfflineAuth to separate files since that logic is also used by gRPC.
* Remove API key support in gRPC now that authentication is required.
