### PR TITLE
Update streaming requests to be created from a prototype.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/CallSetUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/CallSetUtils.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import com.google.api.services.genomics.model.CallSet;
+import com.google.common.base.Function;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+/**
+ * A collection of utility methods for working with call sets.
+ *
+ */
+public class CallSetUtils {
+
+  /**
+   * Given a collection of callsets, return all the names.
+   */
+  public static final Function<CallSet, String> GET_NAMES = new Function<CallSet, String>() {
+    @Override
+    public String apply(CallSet c) {
+      return c.getName();
+    }
+  };
+
+  /**
+   * Given a collection of callsets, return all the ids.
+   */
+  public static final Function<CallSet, String> GET_IDS = new Function<CallSet, String>() {
+    @Override
+    public String apply(CallSet c) {
+      return c.getId();
+    }
+  };
+
+  /**
+   * Create a bi-directional map of names to ids for a collection of callsets.
+   *
+   * As a side effect, this will throw an IllegalArgumentException when the collection of callsets
+   * is malformed due to multiple is mapping to the same name.
+   *
+   * @param callSets
+   * @return the bi-directional map
+   */
+  public static final BiMap<String, String> getCallSetNameMapping(Iterable<CallSet> callSets) {
+    BiMap<String, String> idToName = HashBiMap.create();
+    for(CallSet callSet : callSets) {
+      // Dev Note: Be sure to keep this map loading as id -> name since it ensures that
+      // the values are unique.
+      idToName.put(callSet.getId(), callSet.getName());
+    }
+    return idToName.inverse();
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/utils/Contig.java
+++ b/src/main/java/com/google/cloud/genomics/utils/Contig.java
@@ -21,8 +21,6 @@ import static java.util.Objects.hash;
 import static java.util.Objects.requireNonNull;
 
 import com.google.api.client.util.Preconditions;
-import com.google.api.services.genomics.model.SearchReadsRequest;
-import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
@@ -32,7 +30,6 @@ import com.google.genomics.v1.StreamVariantsRequest;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -110,20 +107,12 @@ public class Contig implements Serializable {
     return shards;
   }
 
-  @Deprecated // Remove this when fully migrated to gRPC.
-  SearchVariantsRequest getSearchVariantsRequest(String variantSetId) {
-    return new SearchVariantsRequest()
-        .setVariantSetIds(Collections.singletonList(variantSetId))
-        .setReferenceName(referenceName)
-        .setStart(start)
-        .setEnd(end);
-  }
-
   /**
    * Construct a StreamVariantsRequest for the Contig.
    * @param variantSetId
    * @return the request object
    */
+  @Deprecated
   public StreamVariantsRequest getStreamVariantsRequest(String variantSetId) {
     return StreamVariantsRequest.newBuilder()
         .setVariantSetId(variantSetId)
@@ -133,20 +122,12 @@ public class Contig implements Serializable {
         .build();
   }
 
-  @Deprecated // Remove this when fully migrated to gRPC.
-  SearchReadsRequest getSearchReadsRequest(String readGroupSetId) {
-    return new SearchReadsRequest()
-        .setReadGroupSetIds(Collections.singletonList(readGroupSetId))
-        .setReferenceName(referenceName)
-        .setStart(start)
-        .setEnd(end);
-  }
-
   /**
    * Construct a StreamReadsRequest for the Contig.
    * @param readGroupSetId
    * @return the request object
    */
+  @Deprecated
   public StreamReadsRequest getStreamReadsRequest(String readGroupSetId) {
     return StreamReadsRequest.newBuilder()
         .setReadGroupSetId(readGroupSetId)
@@ -156,5 +137,32 @@ public class Contig implements Serializable {
         .build();
   }
 
+  /**
+   * Construct a StreamVariantsRequest for the Contig using a prototype using a prototype request.
+   *
+   * @param prototype A partially filled in request object.
+   * @return the request object
+   */
+  public StreamVariantsRequest getStreamVariantsRequest(StreamVariantsRequest prototype) {
+    return StreamVariantsRequest.newBuilder(prototype)
+        .setReferenceName(referenceName)
+        .setStart(start)
+        .setEnd(end)
+        .build();
+  }
+
+  /**
+   * Construct a StreamReadsRequest for the Contig using a prototype request.
+   *
+   * @param prototype A partially filled in request object.
+   * @return the request object
+   */
+  public StreamReadsRequest getStreamReadsRequest(StreamReadsRequest prototype) {
+    return StreamReadsRequest.newBuilder(prototype)
+        .setReferenceName(referenceName)
+        .setStart(start)
+        .setEnd(end)
+        .build();
+  }
 }
 

--- a/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/GenomicsUtils.java
@@ -138,6 +138,22 @@ public class GenomicsUtils {
   }
 
   /**
+   * Gets CallSets for a given variantSetId using the Genomics API.
+   *
+   * @param variantSetId The id of the variantSet to query.
+   * @param auth The OfflineAuth for the API request.
+   * @return The list of callSet names in the variantSet.
+   * @throws IOException If variantSet does not contain any CallSets.
+   */
+  public static Iterable<CallSet> getCallSets(String variantSetId, OfflineAuth auth)
+      throws IOException {
+    Genomics genomics = GenomicsFactory.builder().build().fromOfflineAuth(auth);
+    return Paginator.Callsets.create(genomics)
+        .search(new SearchCallSetsRequest().setVariantSetIds(Lists.newArrayList(variantSetId)),
+            "callSets,nextPageToken");
+  }
+
+  /**
    * Gets CallSets Names for a given variantSetId using the Genomics API.
    *
    * @param variantSetId The id of the variantSet to query.

--- a/src/test/java/com/google/cloud/genomics/utils/CallSetUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/CallSetUtilsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.utils;
+
+import com.google.api.services.genomics.model.CallSet;
+import com.google.common.collect.BiMap;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class CallSetUtilsTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testGetCallSetNameMapping() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("value already present: duplicate");
+
+    List<CallSet> callSets = Arrays.asList(
+        new CallSet().setName("unique").setId("123-0"),
+        new CallSet().setName("duplicate").setId("123-1"),
+        new CallSet().setName("duplicate").setId("123-2")
+        );
+    BiMap<String, String> namesToIds = CallSetUtils.getCallSetNameMapping(callSets);
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/utils/ContigTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ContigTest.java
@@ -20,9 +20,10 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 
-import com.google.api.services.genomics.model.SearchReadsRequest;
-import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.genomics.v1.StreamReadsRequest;
+import com.google.genomics.v1.StreamVariantsRequest;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,20 +65,74 @@ public class ContigTest {
 
   @Test
   public void testGetVariantsRequest() throws Exception {
-    SearchVariantsRequest request = new Contig("1", 0, 9).getSearchVariantsRequest("vs");
-    assertEquals("vs", request.getVariantSetIds().get(0));
+    StreamVariantsRequest prototype = StreamVariantsRequest.newBuilder()
+        .setProjectId("theProjectId")
+        .setVariantSetId("theVariantSetId")
+        .build();
+    StreamVariantsRequest request = new Contig("1", 0, 9)
+      .getStreamVariantsRequest(prototype);
+    assertEquals("theProjectId", request.getProjectId());
+    assertEquals("theVariantSetId", request.getVariantSetId());
     assertEquals("1", request.getReferenceName());
-    assertEquals(0, request.getStart().longValue());
-    assertEquals(9, request.getEnd().longValue());
+    assertEquals(0, request.getStart());
+    assertEquals(9, request.getEnd());
+  }
+
+  @Test
+  public void testGetVariantsRequestWithCallSetIds() throws Exception {
+    ImmutableSet<String> callSetIds = ImmutableSet.<String>builder()
+        .add("callSetId-0")
+        .add("callSetId-1")
+        .build();
+    StreamVariantsRequest prototype = StreamVariantsRequest.newBuilder()
+        .setProjectId("theProjectId")
+        .setVariantSetId("theVariantSetId")
+        .addAllCallSetIds(callSetIds)
+        .build();
+    StreamVariantsRequest request = new Contig("1", 0, 9)
+      .getStreamVariantsRequest(prototype);
+    assertEquals("theProjectId", request.getProjectId());
+    assertEquals("theVariantSetId", request.getVariantSetId());
+    assertEquals(2, request.getCallSetIdsList().size());
+    assertEquals("callSetId-0", request.getCallSetIds(0));
+    assertEquals("callSetId-1", request.getCallSetIds(1));
+    assertEquals("1", request.getReferenceName());
+    assertEquals(0, request.getStart());
+    assertEquals(9, request.getEnd());
+  }
+
+  @Test
+  public void testGetVariantsRequestWithEmptyCallSetIds() throws Exception {
+    ImmutableSet<String> callSetIds = ImmutableSet.<String>builder()
+        .build();
+    StreamVariantsRequest prototype = StreamVariantsRequest.newBuilder()
+        .setProjectId("theProjectId")
+        .setVariantSetId("theVariantSetId")
+        .addAllCallSetIds(callSetIds)
+        .build();
+    StreamVariantsRequest request = new Contig("1", 0, 9)
+      .getStreamVariantsRequest(prototype);
+    assertEquals("theProjectId", request.getProjectId());
+    assertEquals("theVariantSetId", request.getVariantSetId());
+    assertEquals(0, request.getCallSetIdsList().size());
+    assertEquals("1", request.getReferenceName());
+    assertEquals(0, request.getStart());
+    assertEquals(9, request.getEnd());
   }
 
   @Test
   public void testGetReadsRequest() throws Exception {
-    SearchReadsRequest request = new Contig("1", 0, 9).getSearchReadsRequest("rs");
-    assertEquals("rs", request.getReadGroupSetIds().get(0));
+    StreamReadsRequest prototype = StreamReadsRequest.newBuilder()
+        .setProjectId("theProjectId")
+        .setReadGroupSetId("theReadGroupSetId")
+        .build();
+    StreamReadsRequest request = new Contig("1", 0, 9)
+      .getStreamReadsRequest(prototype);
+    assertEquals("theProjectId", request.getProjectId());
+    assertEquals("theReadGroupSetId", request.getReadGroupSetId());
     assertEquals("1", request.getReferenceName());
-    assertEquals(0, request.getStart().longValue());
-    assertEquals(9, request.getEnd().longValue());
+    assertEquals(0, request.getStart());
+    assertEquals(9, request.getEnd());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/GenomicsUtilsITCase.java
@@ -18,7 +18,10 @@ package com.google.cloud.genomics.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Iterables;
+
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -45,6 +48,13 @@ public class GenomicsUtilsITCase {
     assertThat(GenomicsUtils.getVariantSetIds(IntegrationTestHelper.PLATINUM_GENOMES_DATASET,
         IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)));
+  }
+
+  @Test
+  public void testGetCallSets() throws Exception {
+    assertThat(Iterables.transform(GenomicsUtils.getCallSets(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+        IntegrationTestHelper.getAuthFromApiKey()), CallSetUtils.GET_NAMES),
+        IsIterableContainingInOrder.contains(IntegrationTestHelper.PLATINUM_GENOMES_CALLSET_NAMES));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/IntegrationTestHelper.java
@@ -96,7 +96,14 @@ public class IntegrationTestHelper {
     new ReferenceBound().setReferenceName("chrY").setUpperBound(60032946L)
   };
 
+  // Test configuration constants
+  private static final String TEST_PROJECT = System.getenv("TEST_PROJECT");
   private static final String API_KEY = System.getenv("GOOGLE_API_KEY");
+
+  public static String getTEST_PROJECT() {
+    assertNotNull("You must set the TEST_PROJECT environment variable for this test.", TEST_PROJECT);
+    return TEST_PROJECT;
+  }
 
   /**
    * @return the API_KEY

--- a/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardUtilsITCase.java
@@ -32,87 +32,91 @@ public class ShardUtilsITCase {
 
   @Test
   public void testGetVariantRequestsStringSexChromosomeFilterLongOfflineAuth() throws IOException, GeneralSecurityException {
+    StreamVariantsRequest prototype = StreamVariantsRequest.newBuilder()
+        .setVariantSetId(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
+        .setProjectId(IntegrationTestHelper.getTEST_PROJECT())
+        .build();
 
     StreamVariantsRequest[] EXPECTED_RESULT_XY = {
         new Contig("chrX", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chrX", 150000000L, 156231278L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chrY", 0L, 60032946L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
+        .getStreamVariantsRequest(prototype)
     };
 
     StreamVariantsRequest[] EXPECTED_RESULT = {
         new Contig("chr1", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr1", 150000000L, 250226910L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr10", 0L, 136466007L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr11", 0L, 135762137L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr12", 0L, 134049696L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr13", 0L, 115800144L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr14", 0L, 107857350L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr15", 0L, 103000009L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr16", 0L, 90760361L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr17", 0L, 81983044L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr18", 0L, 78776233L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr19", 0L, 59544813L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr2", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr2", 150000000L, 243800708L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr20", 0L, 62993757L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr21", 0L, 48724643L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr22", 0L, 51891601L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr3", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr3", 150000000L, 198316350L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr4", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr4", 150000000L, 191970744L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr5", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr5", 150000000L, 181054248L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr6", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr6", 150000000L, 171796962L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr7", 0L, 150000000L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr7", 150000000L, 159737113L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr8", 0L, 147299246L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chr9", 0L, 142027288L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET),
+        .getStreamVariantsRequest(prototype),
         new Contig("chrM", 0L, 1000001L)
-        .getStreamVariantsRequest(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
+        .getStreamVariantsRequest(prototype)
     };
 
     // These shards are "too big" to use in practice but for this test it keeps the
     // expected result from getting crazy long.
-    assertThat(ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+    assertThat(ShardUtils.getVariantRequests(prototype,
         SexChromosomeFilter.EXCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
 
     // Include sex chromosomes this time.
-    assertThat(ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
+    assertThat(ShardUtils.getVariantRequests(prototype,
         SexChromosomeFilter.INCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT),
             CoreMatchers.hasItems(EXPECTED_RESULT_XY)));
@@ -120,87 +124,91 @@ public class ShardUtilsITCase {
 
   @Test
   public void testGetReadRequestsStringSexChromosomeFilterLongOfflineAuth() throws IOException, GeneralSecurityException {
+    StreamReadsRequest prototype = StreamReadsRequest.newBuilder()
+        .setReadGroupSetId(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0])
+        .setProjectId(IntegrationTestHelper.getTEST_PROJECT())
+        .build();
 
     StreamReadsRequest[] EXPECTED_RESULT_XY = {
         new Contig("chrX", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chrX", 150000000L, 155270560L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chrY", 0L, 59373566L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0])
+        .getStreamReadsRequest(prototype)
     };
 
     StreamReadsRequest[] EXPECTED_RESULT = {
         new Contig("chr1", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr1", 150000000L, 249250621L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr10", 0L, 135534747L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr11", 0L, 135006516L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr12", 0L, 133851895L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr13", 0L, 115169878L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr14", 0L, 107349540L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr15", 0L, 102531392L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr16", 0L, 90354753L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr17", 0L, 81195210L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr18", 0L, 78077248L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr19", 0L,  59128983L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr2", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr2", 150000000L, 243199373L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr20", 0L, 63025520L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr21", 0L, 48129895L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr22", 0L, 51304566L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr3", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr3", 150000000L, 198022430L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr4", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr4", 150000000L, 191154276L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr5", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr5", 150000000L, 180915260L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr6", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr6", 150000000L, 171115067L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr7", 0L, 150000000L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr7", 150000000L, 159138663L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr8", 0L, 146364022L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chr9", 0L, 141213431L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
+        .getStreamReadsRequest(prototype),
         new Contig("chrM", 0L, 16571L)
-        .getStreamReadsRequest(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0])
+        .getStreamReadsRequest(prototype)
     };
 
     // These shards are "too big" to use in practice but for this test it keeps the
     // expected result from getting crazy long.
-    assertThat(ShardUtils.getReadRequests(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0],
+    assertThat(ShardUtils.getReadRequests(prototype,
         SexChromosomeFilter.EXCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT)));
 
     // Include sex chromosomes this time.
-    assertThat(ShardUtils.getReadRequests(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0],
+    assertThat(ShardUtils.getReadRequests(prototype,
         SexChromosomeFilter.INCLUDE_XY, 150000000L, IntegrationTestHelper.getAuthFromApiKey()),
         CoreMatchers.allOf(CoreMatchers.hasItems(EXPECTED_RESULT),
             CoreMatchers.hasItems(EXPECTED_RESULT_XY)));

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITCase.java
@@ -42,6 +42,10 @@ import java.util.Random;
 @RunWith(JUnit4.class)
 public class FaultyGenomicsServerITCase {
   public static final String SERVER_NAME = "integrationTest";
+  public static final StreamVariantsRequest PROTOTYPE = StreamVariantsRequest.newBuilder()
+      .setProjectId(IntegrationTestHelper.getTEST_PROJECT())
+      .setVariantSetId(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
+      .build();
 
   protected static Server server;
   protected static ManagedChannel genomicsChannel;
@@ -131,8 +135,8 @@ public class FaultyGenomicsServerITCase {
   @Test
   public void testVariantRetries() {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
-            IntegrationTestHelper.PLATINUM_GENOMES_BRCA1_REFERENCES, 1000000000L);
+        ShardUtils.getVariantRequests(PROTOTYPE,
+            1000000000L, IntegrationTestHelper.PLATINUM_GENOMES_BRCA1_REFERENCES);
     VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
     // Dev Note: this data currently comes back as 20 separate lists but this is controlled server-side.

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/FaultyGenomicsServerITLongCase.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.genomics.utils.grpc;
 
-import com.google.cloud.genomics.utils.IntegrationTestHelper;
 import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.ImmutableList;
@@ -38,7 +37,7 @@ public class FaultyGenomicsServerITLongCase extends FaultyGenomicsServerITCase {
 
   // Create one long stream.
   private static final ImmutableList<StreamVariantsRequest> requests = ShardUtils.getVariantRequests(
-      IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET, "chrY:0:60032946", 1000000000L);
+      PROTOTYPE, 1000000000L, "chrY:0:60032946");
   private static final int EXPECTED_CHRY_NUM_VARIANTS = 5971309;
 
   @Test

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/GenomicsStreamIteratorTest.java
@@ -43,6 +43,14 @@ import java.util.Collections;
 @RunWith(JUnit4.class)
 public class GenomicsStreamIteratorTest {
   public static final String SERVER_NAME = "unitTest";
+  public static final StreamReadsRequest PROTOTYPE_READ_REQUEST = StreamReadsRequest.newBuilder()
+      .setReadGroupSetId("theReadGroupSetId")
+      .setProjectId("theProjectId")
+      .build();
+  public static final StreamVariantsRequest PROTOTYPE_VARIANT_REQUEST = StreamVariantsRequest.newBuilder()
+      .setVariantSetId("theVariantSetId")
+      .setProjectId("theProjectId")
+      .build();
 
   protected static Server server;
 
@@ -101,7 +109,7 @@ public class GenomicsStreamIteratorTest {
   @Test
   public void testAllReadsOverlapsStart() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList("fake readgroup set"), "chr7:500:600", 1000000L);
+        ShardUtils.getReadRequests(Collections.singletonList(PROTOTYPE_READ_REQUEST), 1000000L, "chr7:500:600");
 
     ReadStreamIterator iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
@@ -115,7 +123,7 @@ public class GenomicsStreamIteratorTest {
   @Test
   public void testAllVariantsOverlapsStart() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests("fake variant set", "chr7:500:600", 1000000L);
+        ShardUtils.getVariantRequests(PROTOTYPE_VARIANT_REQUEST, 1000000L, "chr7:500:600");
 
     VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
@@ -129,7 +137,7 @@ public class GenomicsStreamIteratorTest {
   @Test
   public void testSomeReadsOverlapsStart() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList("fake readgroup set"), "chr7:499:600", 1000000L);
+        ShardUtils.getReadRequests(Collections.singletonList(PROTOTYPE_READ_REQUEST), 1000000L, "chr7:499:600");
 
     ReadStreamIterator iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
@@ -143,7 +151,7 @@ public class GenomicsStreamIteratorTest {
   @Test
   public void testSomeVariantsOverlapsStart() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests("fake variant set", "chr7:499:600", 1000000L);
+        ShardUtils.getVariantRequests(PROTOTYPE_VARIANT_REQUEST, 1000000L, "chr7:499:600");
 
     VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
@@ -157,7 +165,7 @@ public class GenomicsStreamIteratorTest {
   @Test
   public void testNoReadsOverlapsStart() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList("fake readgroup set"), "chr7:300:600", 1000000L);
+        ShardUtils.getReadRequests(Collections.singletonList(PROTOTYPE_READ_REQUEST), 1000000L, "chr7:300:600");
 
     ReadStreamIterator iter = ReadStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);
@@ -171,7 +179,7 @@ public class GenomicsStreamIteratorTest {
   @Test
   public void testNoVariantsOverlapsStart() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests("fake variant set", "chr7:300:600", 1000000L);
+        ShardUtils.getVariantRequests(PROTOTYPE_VARIANT_REQUEST, 1000000L, "chr7:300:600");
 
     VariantStreamIterator iter = VariantStreamIterator.enforceShardBoundary(createChannel(), requests.get(0),
         ShardBoundary.Requirement.STRICT, null);

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/ReadStreamIteratorITCase.java
@@ -43,6 +43,10 @@ import java.util.List;
 public class ReadStreamIteratorITCase {
   // This small interval overlaps the Klotho SNP.
   static final String REFERENCES = "chr13:33628134:33628138";
+  static final StreamReadsRequest PROTOTYPE = StreamReadsRequest.newBuilder()
+      .setReadGroupSetId(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0])
+      .setProjectId(IntegrationTestHelper.getTEST_PROJECT())
+      .build();
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -50,8 +54,8 @@ public class ReadStreamIteratorITCase {
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
-        REFERENCES, 100L);
+        ShardUtils.getReadRequests(Collections.singletonList(PROTOTYPE),
+        100L, REFERENCES);
     assertEquals(1, requests.size());
 
     Iterator<StreamReadsResponse> iter =
@@ -77,8 +81,8 @@ public class ReadStreamIteratorITCase {
   @Test
   public void testPartialResponses() throws IOException, GeneralSecurityException {
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
-        REFERENCES, 100L);
+        ShardUtils.getReadRequests(Collections.singletonList(PROTOTYPE),
+        100L, REFERENCES);
     assertEquals(1, requests.size());
 
     Iterator<StreamReadsResponse> iter =
@@ -104,8 +108,8 @@ public class ReadStreamIteratorITCase {
         + "At a minimum include 'alignments(alignment)' to enforce a strict shard boundary."));
 
     ImmutableList<StreamReadsRequest> requests =
-        ShardUtils.getReadRequests(Collections.singletonList(IntegrationTestHelper.PLATINUM_GENOMES_READGROUPSETS[0]),
-        REFERENCES, 100L);
+        ShardUtils.getReadRequests(Collections.singletonList(PROTOTYPE),
+        100L, REFERENCES);
     assertEquals(1, requests.size());
 
     Iterator<StreamReadsResponse> iter =

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantStreamIteratorITCase.java
@@ -40,14 +40,19 @@ import java.util.List;
 
 @RunWith(JUnit4.class)
 public class VariantStreamIteratorITCase {
+  public static final StreamVariantsRequest PROTOTYPE = StreamVariantsRequest.newBuilder()
+      .setVariantSetId(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET)
+      .setProjectId(IntegrationTestHelper.getTEST_PROJECT())
+      .build();
+
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testBasic() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
-            IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+        ShardUtils.getVariantRequests(PROTOTYPE,
+            100L, IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES);
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =
@@ -77,8 +82,8 @@ public class VariantStreamIteratorITCase {
   @Test
   public void testEmptyRegion() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
-            "chrDoesNotExist:100:200", 100L);
+        ShardUtils.getVariantRequests(PROTOTYPE,
+            100L, "chrDoesNotExist:100:200");
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =
@@ -97,8 +102,8 @@ public class VariantStreamIteratorITCase {
   @Test
   public void testPartialResponses() throws IOException, GeneralSecurityException {
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
-            IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+        ShardUtils.getVariantRequests(PROTOTYPE,
+            100L, IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES);
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =
@@ -125,8 +130,8 @@ public class VariantStreamIteratorITCase {
         + "At a minimum include 'variants(start)' to enforce a strict shard boundary."));
 
     ImmutableList<StreamVariantsRequest> requests =
-        ShardUtils.getVariantRequests(IntegrationTestHelper.PLATINUM_GENOMES_VARIANTSET,
-            IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES, 100L);
+        ShardUtils.getVariantRequests(PROTOTYPE,
+            100L, IntegrationTestHelper.PLATINUM_GENOMES_KLOTHO_REFERENCES);
     assertEquals(1, requests.size());
 
     Iterator<StreamVariantsResponse> iter =


### PR DESCRIPTION
This allows pipelines to be run on a subset of callsets.
