### PR TITLE
Modify the variant merge strategies to be aware of the window.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/ShardBoundary.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ShardBoundary.java
@@ -14,10 +14,8 @@
 package com.google.cloud.genomics.utils;
 
 import com.google.api.client.util.Strings;
-import com.google.cloud.genomics.utils.grpc.VariantUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.genomics.v1.Read;
 import com.google.genomics.v1.Variant;
 
@@ -42,11 +40,6 @@ public class ShardBoundary {
    * Use STRICT if data overlapping the start of the shard should be excluded.
    */
   STRICT,
-  /**
-   * Use NON_VARIANT_OVERLAPS when non-variant segments overlapping the start of the shard should be
-   * retained but variants overlapping the start of the shard should be excluded.
-   */
-  NON_VARIANT_OVERLAPS
   }
 
   private static final Pattern READ_FIELD_PATTERN = Pattern.compile(".*\\p{Punct}alignment\\p{Punct}.*");
@@ -90,16 +83,5 @@ public class ShardBoundary {
         return read.getAlignment().getPosition().getPosition() >= start;
       }
     };
-  }
-
-  /**
-   * Predicate expressing the logic for which variants and non-variant segments should and should
-   * not be included in the shard.
-   *
-   * @param start The start position of the shard.
-   * @return Whether the variant would be included in a non-variant overlaps shard boundary.
-   */
-  public static Predicate<Variant> getNonVariantOverlapsPredicate(final long start, final String fields) {
-    return Predicates.or(VariantUtils.IS_NON_VARIANT_SEGMENT, getStrictVariantPredicate(start, fields));
   }
 }

--- a/src/main/java/com/google/cloud/genomics/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/VariantUtils.java
@@ -86,7 +86,7 @@ public class VariantUtils {
       HAS_ALTERNATE, new Predicate<Variant>() {
         @Override
         public boolean apply(Variant variant) {
-          return Iterables.any(variant.getAlternateBases(),
+          return Iterables.all(variant.getAlternateBases(),
               Predicates.equalTo(GATK_NON_VARIANT_SEGMENT_ALT));
         }
       });

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariants.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariants.java
@@ -24,8 +24,9 @@ import java.util.List;
 
 /**
  * This strategy converts data with non-variant segments (such as data that was in
- * source format Genome VCF (gVCF) or Complete Genomics) to variant-only data with calls from
- * non-variant-segments merged into the variants with which they overlap.
+ * source format Genome VCF (gVCF) or Complete Genomics) to variant-only data occurring
+ * within the genomic window with calls from non-variant-segments merged into the
+ * variants with which they overlap.
  *
  * Dealing with ambiguous data:
  *  If a particular sample has both a variant and one or more non-variant segments that overlap it,
@@ -34,11 +35,9 @@ import java.util.List;
 public class MergeNonVariantSegmentsWithVariants implements VariantMergeStrategy {
 
   @Override
-  public void merge(Iterable<Variant> variants, VariantEmitterStrategy emitter) {
+  public void merge(Long windowStart, Iterable<Variant> variants, VariantEmitterStrategy emitter) {
     // The sort order is critical here so that candidate overlapping reference matching blocks
     // occur prior to any variants they may overlap.
-    // TODO optimization: remove this sort by restructuring the code to depend upon the order in which data
-    // is returned by the the genomics API which is sorted by (variantset id, contig, start pos, variant id).
     List<Variant> records = Lists.newArrayList(variants);  // Get a modifiable list.
     Collections.sort(records, VariantUtils.NON_VARIANT_SEGMENT_COMPARATOR);
 
@@ -48,6 +47,10 @@ public class MergeNonVariantSegmentsWithVariants implements VariantMergeStrategy
 
     for (Variant record : records) {
       if (!VariantUtils.IS_NON_VARIANT_SEGMENT.apply(record)) {
+        if (record.getStart() < windowStart) {
+          // This is a variant that begins before our window.  Skip it.
+          continue;
+        }
         Builder updatedRecord = Variant.newBuilder(record);
         for (Iterator<Variant> iterator = blockRecords.iterator(); iterator.hasNext();) {
           Variant blockRecord = iterator.next();

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantMergeStrategy.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantMergeStrategy.java
@@ -21,15 +21,13 @@ import com.google.genomics.v1.Variant;
 public interface VariantMergeStrategy {
 
   /**
-   * Given an ordered collection of variants and non-variant segments that overlap a genomic region,
+   * Given a collection of variants and non-variant segments that overlap a genomic region,
    * emit their merged representation via the emitter.
    *
-   * The ordering of the input is assumed to be the order in which data is returned by the the
-   * genomics API which is sorted by (variantset id, contig, start pos, variant id).
-   *
-   * @param variants
-   * @param emitter
+   * @param windowStart - use this to identify records that begin prior to the region we are computing, but overlap it
+   * @param variants - the variants that overlap the region we are computing
+   * @param emitter - the strategy instance to use to emit results
    */
-  public void merge(Iterable<Variant> variants, VariantEmitterStrategy emitter);
+  public void merge(Long windowStart, Iterable<Variant> variants, VariantEmitterStrategy emitter);
 
 }

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantStreamIterator.java
@@ -72,8 +72,6 @@ public class VariantStreamIterator
     Predicate<Variant> shardPredicate;
     if(ShardBoundary.Requirement.STRICT == shardBoundary) {
       shardPredicate = ShardBoundary.getStrictVariantPredicate(request.getStart(), fields);
-    } else if(ShardBoundary.Requirement.NON_VARIANT_OVERLAPS == shardBoundary) {
-      shardPredicate = ShardBoundary.getNonVariantOverlapsPredicate(request.getStart(), fields);
     } else {
       shardPredicate = null;
     }

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/VariantUtils.java
@@ -100,7 +100,7 @@ public class VariantUtils {
   public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT = new Predicate<Variant>() {
         @Override
         public boolean apply(Variant variant) {
-          return Iterables.any(variant.getAlternateBasesList(),
+          return Iterables.all(variant.getAlternateBasesList(),
               Predicates.equalTo(GATK_NON_VARIANT_SEGMENT_ALT));
         }
       };

--- a/src/test/java/com/google/cloud/genomics/utils/ShardBoundaryTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/ShardBoundaryTest.java
@@ -15,9 +15,7 @@ package com.google.cloud.genomics.utils;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
@@ -105,22 +103,4 @@ public class ShardBoundaryTest {
         + "At a minimum include 'alignments(alignment)' to enforce a strict shard boundary."));
     ShardBoundary.getStrictReadPredicate(123, "alignments(alignedSequence)");
   }
-
-  @Test
-  public void testGetNonVariantOverlapsPredicate() {
-    long start = 1000L;
-
-    Variant overlapStart = Variant.newBuilder().setReferenceBases("T").addAlternateBases("A").setStart(900L).build();
-    Variant overlapStartNonVariant = Variant.newBuilder().setReferenceBases("T").setStart(900L).setEnd(1005L).build();
-    Variant overlapStartGatkNonVariant = Variant.newBuilder().setReferenceBases("T")
-        .addAlternateBases("A").addAlternateBases(VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT)
-        .setStart(900L).setEnd(1005L).build();
-
-    Predicate<Variant> shardPredicate = ShardBoundary.getNonVariantOverlapsPredicate(start, null);
-
-    assertFalse(shardPredicate.apply(overlapStart));
-    assertTrue(shardPredicate.apply(overlapStartNonVariant));
-    assertTrue(shardPredicate.apply(overlapStartGatkNonVariant));
-  }
-
 }

--- a/src/test/java/com/google/cloud/genomics/utils/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/VariantUtilsTest.java
@@ -61,7 +61,9 @@ public class VariantUtilsTest {
         200001, "A", null, (VariantCall[]) null)));
     assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
         200001, "A", Arrays.asList(VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT), (VariantCall[]) null)));
-    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
+
+    // A variant with a <NON_REF> alternate.
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(TestHelper.makeVariant("chr7", 200000,
         200001, "A", Arrays.asList("T", VariantUtils.GATK_NON_VARIANT_SEGMENT_ALT), (VariantCall[]) null)));
   }
 

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteITCase.java
@@ -100,7 +100,7 @@ public class MergeAllVariantsAtSameSiteITCase {
         .addCalls(TestHelper.makeCall("NA12886", 0, 0))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(iter.next().getVariantsList(),
+    VariantMergeStrategyTestHelper.mergeTest(iter.next().getVariantsList(),
         Arrays.asList(expectedOutput1),
         MergeAllVariantsAtSameSite.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteITCase.java
@@ -73,7 +73,7 @@ public class MergeAllVariantsAtSameSiteITCase {
     Iterator<StreamVariantsResponse> iter =
         VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
             requests.get(0),
-            ShardBoundary.Requirement.NON_VARIANT_OVERLAPS,
+            ShardBoundary.Requirement.OVERLAPS,
             "variants(alternateBases,calls(callSetName,genotype),end,referenceBases,referenceName,start)");
 
     // Platinum genomes has both a snp and an insertion at this genomic site
@@ -100,7 +100,7 @@ public class MergeAllVariantsAtSameSiteITCase {
         .addCalls(TestHelper.makeCall("NA12886", 0, 0))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(iter.next().getVariantsList(),
+    VariantMergeStrategyTestHelper.mergeTest(requests.get(0).getStart(), iter.next().getVariantsList(),
         Arrays.asList(expectedOutput1),
         MergeAllVariantsAtSameSite.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteTest.java
@@ -47,13 +47,13 @@ public class MergeAllVariantsAtSameSiteTest {
         .addCalls(TestHelper.makeCall("het-RA-[T]", 0, 3))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(input, Arrays.asList(expectedOutput),
+    VariantMergeStrategyTestHelper.mergeTest(100L, input, Arrays.asList(expectedOutput),
         MergeAllVariantsAtSameSite.class);
 
     // Ensure that the result is stable regardless of the input order of these Variants.
     for (int i = 0; i < 5; i++) {
       Collections.shuffle(input);
-      VariantMergeStrategyTestHelper.mergeTest(input, Arrays.asList(expectedOutput),
+      VariantMergeStrategyTestHelper.mergeTest(100L, input, Arrays.asList(expectedOutput),
           MergeAllVariantsAtSameSite.class);
     }
   }
@@ -84,13 +84,13 @@ public class MergeAllVariantsAtSameSiteTest {
         .addCalls(TestHelper.makeCall("het-AA-[C, CC]", 1, 2))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(insert1BiAllelic, insert2BiAllelic, snpInsertMultiAllelic),
+    VariantMergeStrategyTestHelper.mergeTest(100L, Arrays.asList(insert1BiAllelic, insert2BiAllelic, snpInsertMultiAllelic),
         Arrays.asList(expectedOutput1),
         MergeAllVariantsAtSameSite.class);
-    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(delete2BiAllelic, indelMultiAllelic),
+    VariantMergeStrategyTestHelper.mergeTest(100L, Arrays.asList(delete2BiAllelic, indelMultiAllelic),
         Arrays.asList(expectedOutput2),
         MergeAllVariantsAtSameSite.class);
-    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(delete1BiAllelic, deleteMultiAllelic),
+    VariantMergeStrategyTestHelper.mergeTest(100L, Arrays.asList(delete1BiAllelic, deleteMultiAllelic),
         Arrays.asList(expectedOutput3),
         MergeAllVariantsAtSameSite.class);
 
@@ -99,7 +99,7 @@ public class MergeAllVariantsAtSameSiteTest {
         insert1BiAllelic, insert2BiAllelic, snpInsertMultiAllelic);
     for (int i = 0; i < 5; i++) {
       Collections.shuffle(input);
-      VariantMergeStrategyTestHelper.mergeTest(input,
+      VariantMergeStrategyTestHelper.mergeTest(100L, input,
           Arrays.asList(expectedOutput1, expectedOutput2, expectedOutput3),
           MergeAllVariantsAtSameSite.class);
     }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeAllVariantsAtSameSiteTest.java
@@ -47,13 +47,13 @@ public class MergeAllVariantsAtSameSiteTest {
         .addCalls(TestHelper.makeCall("het-RA-[T]", 0, 3))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(input, Arrays.asList(expectedOutput),
+    VariantMergeStrategyTestHelper.mergeTest(input, Arrays.asList(expectedOutput),
         MergeAllVariantsAtSameSite.class);
 
     // Ensure that the result is stable regardless of the input order of these Variants.
     for (int i = 0; i < 5; i++) {
       Collections.shuffle(input);
-      VariantMergeStrategyTest.mergeTest(input, Arrays.asList(expectedOutput),
+      VariantMergeStrategyTestHelper.mergeTest(input, Arrays.asList(expectedOutput),
           MergeAllVariantsAtSameSite.class);
     }
   }
@@ -84,13 +84,13 @@ public class MergeAllVariantsAtSameSiteTest {
         .addCalls(TestHelper.makeCall("het-AA-[C, CC]", 1, 2))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(Arrays.asList(insert1BiAllelic, insert2BiAllelic, snpInsertMultiAllelic),
+    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(insert1BiAllelic, insert2BiAllelic, snpInsertMultiAllelic),
         Arrays.asList(expectedOutput1),
         MergeAllVariantsAtSameSite.class);
-    VariantMergeStrategyTest.mergeTest(Arrays.asList(delete2BiAllelic, indelMultiAllelic),
+    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(delete2BiAllelic, indelMultiAllelic),
         Arrays.asList(expectedOutput2),
         MergeAllVariantsAtSameSite.class);
-    VariantMergeStrategyTest.mergeTest(Arrays.asList(delete1BiAllelic, deleteMultiAllelic),
+    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(delete1BiAllelic, deleteMultiAllelic),
         Arrays.asList(expectedOutput3),
         MergeAllVariantsAtSameSite.class);
 
@@ -99,7 +99,7 @@ public class MergeAllVariantsAtSameSiteTest {
         insert1BiAllelic, insert2BiAllelic, snpInsertMultiAllelic);
     for (int i = 0; i < 5; i++) {
       Collections.shuffle(input);
-      VariantMergeStrategyTest.mergeTest(input,
+      VariantMergeStrategyTestHelper.mergeTest(input,
           Arrays.asList(expectedOutput1, expectedOutput2, expectedOutput3),
           MergeAllVariantsAtSameSite.class);
     }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsITCase.java
@@ -105,7 +105,7 @@ public class MergeNonVariantSegmentsWithSnpsITCase {
         .addCalls(TestHelper.makeCall("NA12884", 0, 0))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(iter.next().getVariantsList(),
+    VariantMergeStrategyTestHelper.mergeTest(iter.next().getVariantsList(),
         Arrays.asList(expectedOutput1, expectedOutput2),
         MergeNonVariantSegmentsWithSnps.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsITCase.java
@@ -73,7 +73,7 @@ public class MergeNonVariantSegmentsWithSnpsITCase {
     Iterator<StreamVariantsResponse> iter =
         VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
             requests.get(0),
-            ShardBoundary.Requirement.NON_VARIANT_OVERLAPS,
+            ShardBoundary.Requirement.OVERLAPS,
             "variants(alternateBases,calls(callSetName,genotype),end,referenceBases,referenceName,start)");
 
     // Platinum genomes has both a snp and an insertion at this genomic site.
@@ -105,7 +105,7 @@ public class MergeNonVariantSegmentsWithSnpsITCase {
         .addCalls(TestHelper.makeCall("NA12884", 0, 0))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(iter.next().getVariantsList(),
+    VariantMergeStrategyTestHelper.mergeTest(requests.get(0).getStart(), iter.next().getVariantsList(),
         Arrays.asList(expectedOutput1, expectedOutput2),
         MergeNonVariantSegmentsWithSnps.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsTest.java
@@ -50,7 +50,7 @@ public class MergeNonVariantSegmentsWithSnpsTest {
         .addCalls(TestHelper.makeCall("hom-AA-[AC]", 1,1))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
+    VariantMergeStrategyTestHelper.mergeTest(200000L, Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
         Arrays.asList(expectedInsert, expectedSnp1, expectedSnp2),
         MergeNonVariantSegmentsWithSnps.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithSnpsTest.java
@@ -50,7 +50,7 @@ public class MergeNonVariantSegmentsWithSnpsTest {
         .addCalls(TestHelper.makeCall("hom-AA-[AC]", 1,1))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
+    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
         Arrays.asList(expectedInsert, expectedSnp1, expectedSnp2),
         MergeNonVariantSegmentsWithSnps.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsITCase.java
@@ -73,7 +73,7 @@ public class MergeNonVariantSegmentsWithVariantsITCase {
     Iterator<StreamVariantsResponse> iter =
         VariantStreamIterator.enforceShardBoundary(IntegrationTestHelper.getAuthFromApplicationDefaultCredential(),
             requests.get(0),
-            ShardBoundary.Requirement.NON_VARIANT_OVERLAPS,
+            ShardBoundary.Requirement.OVERLAPS,
             "variants(alternateBases,calls(callSetName,genotype),end,referenceBases,referenceName,start)");
 
     // Platinum genomes has both a snp and an insertion at this genomic site.
@@ -121,7 +121,7 @@ public class MergeNonVariantSegmentsWithVariantsITCase {
         .addCalls(TestHelper.makeCall("NA12884", 0, 0))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(iter.next().getVariantsList(),
+    VariantMergeStrategyTestHelper.mergeTest(requests.get(0).getStart(), iter.next().getVariantsList(),
         Arrays.asList(expectedOutput1, expectedOutput2),
         MergeNonVariantSegmentsWithVariants.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsITCase.java
@@ -121,7 +121,7 @@ public class MergeNonVariantSegmentsWithVariantsITCase {
         .addCalls(TestHelper.makeCall("NA12884", 0, 0))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(iter.next().getVariantsList(),
+    VariantMergeStrategyTestHelper.mergeTest(iter.next().getVariantsList(),
         Arrays.asList(expectedOutput1, expectedOutput2),
         MergeNonVariantSegmentsWithVariants.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsTest.java
@@ -51,7 +51,7 @@ public class MergeNonVariantSegmentsWithVariantsTest {
         .addCalls(TestHelper.makeCall("hom-RR-[]", 0,0))
         .build();
 
-    VariantMergeStrategyTest.mergeTest(Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
+    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
         Arrays.asList(expectedInsert, expectedSnp1, expectedSnp2),
         MergeNonVariantSegmentsWithVariants.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/MergeNonVariantSegmentsWithVariantsTest.java
@@ -51,7 +51,7 @@ public class MergeNonVariantSegmentsWithVariantsTest {
         .addCalls(TestHelper.makeCall("hom-RR-[]", 0,0))
         .build();
 
-    VariantMergeStrategyTestHelper.mergeTest(Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
+    VariantMergeStrategyTestHelper.mergeTest(200000L, Arrays.asList(snp1, snp2, insert, blockRecord1, blockRecord2),
         Arrays.asList(expectedInsert, expectedSnp1, expectedSnp2),
         MergeNonVariantSegmentsWithVariants.class);
   }

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantMergeStrategyTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantMergeStrategyTestHelper.java
@@ -35,13 +35,13 @@ public class VariantMergeStrategyTestHelper {
     }
   }
 
-  public static void mergeTest(List<Variant> input, List<Variant> expectedOutput,
+  public static void mergeTest(Long windowStart, List<Variant> input, List<Variant> expectedOutput,
       Class<? extends VariantMergeStrategy> clazz) throws InstantiationException, IllegalAccessException {
     VariantMergeStrategy merger = clazz.newInstance();
     VariantMergeStrategyTestHelper.AccumulatingVariantEmitter emitter =
         new VariantMergeStrategyTestHelper.AccumulatingVariantEmitter();
 
-    merger.merge(input, emitter);
+    merger.merge(windowStart, input, emitter);
     List<Variant> output = emitter.getVariants();
     assertEquals(expectedOutput.size(), output.size());
 

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantMergeStrategyTestHelper.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantMergeStrategyTestHelper.java
@@ -20,7 +20,7 @@ import com.google.genomics.v1.Variant;
 import java.util.ArrayList;
 import java.util.List;
 
-public class VariantMergeStrategyTest {
+public class VariantMergeStrategyTestHelper {
 
   public static class AccumulatingVariantEmitter implements VariantEmitterStrategy {
     private List<Variant> results = new ArrayList();
@@ -38,8 +38,8 @@ public class VariantMergeStrategyTest {
   public static void mergeTest(List<Variant> input, List<Variant> expectedOutput,
       Class<? extends VariantMergeStrategy> clazz) throws InstantiationException, IllegalAccessException {
     VariantMergeStrategy merger = clazz.newInstance();
-    VariantMergeStrategyTest.AccumulatingVariantEmitter emitter =
-        new VariantMergeStrategyTest.AccumulatingVariantEmitter();
+    VariantMergeStrategyTestHelper.AccumulatingVariantEmitter emitter =
+        new VariantMergeStrategyTestHelper.AccumulatingVariantEmitter();
 
     merger.merge(input, emitter);
     List<Variant> output = emitter.getVariants();

--- a/src/test/java/com/google/cloud/genomics/utils/grpc/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/utils/grpc/VariantUtilsTest.java
@@ -87,7 +87,9 @@ public class VariantUtilsTest {
         TestHelper.makeVariant("chr17", 100, "C", TestHelper.EMPTY_ALT_LIST, "hom-RR").build()));
     assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(
         TestHelper.makeVariant("chr17", 100, "C", Arrays.asList(GATK_ALT), "hom-RR").build()));
-    assertTrue(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(
+
+    // A variant with a <NON_REF> alternate.
+    assertFalse(VariantUtils.IS_NON_VARIANT_SEGMENT.apply(
         TestHelper.makeVariant("chr17", 100, "C", Arrays.asList("G", GATK_ALT), "hom-RR").build()));
   }
 
@@ -170,7 +172,7 @@ public class VariantUtilsTest {
         TestHelper.makeVariant("2", 10, 11, "A", Arrays.asList(GATK_ALT)).build(),
         TestHelper.makeVariant("2", 10, 11, "A", Arrays.asList("C")).build()));
 
-    assertTrue(0 > comparator.compare(
+    assertTrue(0 < comparator.compare(
         TestHelper.makeVariant("2", 10, 11, "A", Arrays.asList("G", GATK_ALT)).build(),
         TestHelper.makeVariant("2", 10, 11, "A", Arrays.asList("C")).build()));
   }


### PR DESCRIPTION
Also:
* Don't assume the merge strategy is receiving data already in order.  This will not be true when the collection passed was created by a GroupByKey instead of pulled directly from the Variants API.
* Revert back to prior definition of non-variant segment and treat records with 'NON_REF' and additional values in alternate bases as variants (because sometimes they are variants).
* Remove obsolete Shard Boundary predicate.