### PR TITLE
Avoid reuse of stateful static TextTagCodec - fixes concurrent use

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/ReadUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/ReadUtils.java
@@ -272,9 +272,6 @@ public class ReadUtils {
     return result != null ? result : "Z";
   }
 
-  /** Codec used for converting know SAM tags and their values, from strings to Objects */
-  private static TextTagCodec textTagCodec = new TextTagCodec();
-
   public static final SAMRecord makeSAMRecord(Read read, SAMFileHeader header) {
     SAMRecord record = new SAMRecord(header);
     if (read.getFragmentName() != null) {
@@ -347,6 +344,7 @@ public class ReadUtils {
       record.setBaseQualities(qualityArray);
     }
 
+    TextTagCodec textTagCodec = new TextTagCodec();
     Map<String, List<Object>> tags = read.getInfo();
     if (tags != null) {
       for (String tag : tags.keySet()) {

--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadUtils.java
@@ -234,9 +234,6 @@ public class ReadUtils extends com.google.cloud.genomics.utils.ReadUtils {
     return result != null ? result : "Z";
   }
 
-  /** Codec used for converting know SAM tags and their values, from strings to Objects */
-  private static TextTagCodec textTagCodec = new TextTagCodec();
-
   public static final SAMRecord makeSAMRecord(Read read, SAMFileHeader header) {
     SAMRecord record = new SAMRecord(header);
     if (read.getFragmentName() != null) {
@@ -308,6 +305,7 @@ public class ReadUtils extends com.google.cloud.genomics.utils.ReadUtils {
       record.setBaseQualities(qualityArray);
     }
 
+    TextTagCodec textTagCodec = new TextTagCodec();
     Map<String, ListValue> tags = read.getInfo();
     if (tags != null) {
       for (String tag : tags.keySet()) {


### PR DESCRIPTION
The behavior of `ReadUtils` without this fix is undefined. However, it is very likely to cause tag unmarshalling failures when used concurrently, e.g. `htsjdk.samtools.SAMFormatException: Tag of type i should have signed decimal value`.