### PR TITLE
Don't set the RG tag using read.getReadGroupId()

### DIFF
--- a/src/main/java/com/google/cloud/genomics/utils/grpc/ReadUtils.java
+++ b/src/main/java/com/google/cloud/genomics/utils/grpc/ReadUtils.java
@@ -239,9 +239,6 @@ public class ReadUtils extends com.google.cloud.genomics.utils.ReadUtils {
     if (read.getFragmentName() != null) {
       record.setReadName(read.getFragmentName());
     }
-    if (read.getReadGroupId() != null && !read.getReadGroupId().isEmpty()) {
-      record.setAttribute("RG" ,read.getReadGroupId());
-    }
     // Set flags, as advised in http://google-genomics.readthedocs.org/en/latest/migrating_tips.html
     int flags = getFlags(read);
     record.setFlags(flags);


### PR DESCRIPTION
In practice these values have different semantics. In the Readstore API, the `readGroupId` is a server-generated ID which corresponds to a read group that the user imported. Every Read in the Readstore belongs to a read group, meaning that even if the original caller imported reads without a read group, we would allocate a new one for them.

This "RG" tag will already be set everywhere we would want to consume it downstream.